### PR TITLE
Use the configured error handler for unknown urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.swo
 node_modules/
 .idea
+/test/sandbox

--- a/package.json
+++ b/package.json
@@ -21,7 +21,12 @@
   "devDependencies": {
     "mocha": "~1.13.0",
     "chai": "~1.8.1",
-    "temp": "~0.6.0"
+    "temp": "~0.6.0",
+    "supertest": "~0.8.1",
+    "strong-agent": "~0.2.18",
+    "strong-cluster-control": "~0.2.1",
+    "fs-tools": "~0.2.10",
+    "loopback-explorer": "~1.0.0"
   },
   "optionalDependencies": {
     "express": "~3.4.4",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,57 @@
+var fs = require('fs');
+
+var temp = require('temp');
+var async = require('async');
+
+var Project = require('../').models.Project;
+
+var expect = require('chai').expect;
+var request = request = require('supertest');
+
+describe('Generated project', function() {
+  beforeEach(givenEmptySandbox);
+
+  describe('of type "empty"', function() {
+    beforeEach(function(done) {
+      Project.createFromTemplate(SANDBOX, 'empty', done);
+    });
+
+    it('starts', function(done) {
+      // This is a smoke test checking that the template generates
+      // - a valid definition of models and datasources
+      // - a valid configuration of express routes
+      var app = require(SANDBOX);
+      request(app)
+        .get('/explorer/')
+        .expect(200)
+        .end(done);
+    });
+
+    it('returns json response for unknown URLs', function(done) {
+      var app = require(SANDBOX);
+      request(app)
+        .get('/unhandled-url')
+        .set('Accept', 'application/json')
+        .expect(404)
+        .expect('Content-Type', /json/)
+        .end(done);
+    });
+  });
+
+  describe('of type "mobile', function() {
+    beforeEach(function(done) {
+      Project.createFromTemplate(SANDBOX, 'mobile', done);
+    });
+
+    it.skip('starts', function(done) {
+      // This is a smoke test checking that the template generates
+      // - a valid definition of models and datasources
+      // - a valid configuration of express routes
+      var app = require(SANDBOX);
+      request(app)
+        .get('/explorer/')
+        .expect(200)
+        .end(done);
+    });
+  });
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/support

--- a/test/support.js
+++ b/test/support.js
@@ -1,6 +1,8 @@
 var assert = require('assert');
 var fs = require('fs');
+var path = require('path');
 var expect = require('chai').expect;
+var fstools = require('fs-tools');
 
 assertFileExists = function (file) {
   assert(fs.existsSync(file), file + ' does not exist');
@@ -11,3 +13,20 @@ assertJSONFileHas = function(file, propertyPath, val) {
   var obj = JSON.parse(contents);
   expect(obj).to.have.deep.property(propertyPath, val);
 }
+
+SANDBOX = path.resolve(__dirname, 'sandbox/');
+
+givenEmptySandbox = function(cb) {
+  fstools.remove(SANDBOX, cb);
+
+  // Remove any cached modules from SANDBOX
+  for (var key in require.cache) {
+    if (key.slice(0, SANDBOX.length) == SANDBOX)
+      delete require.cache[key];
+  }
+}
+
+// Let express know that we are runing from unit-tests
+// This way the default error handler does not log
+// errors to STDOUT
+process.env.NODE_ENV = 'test';


### PR DESCRIPTION
Reordered middleware setup in app.js and added urlNotFound handler. Started integration tests that boot the application and issue mock requests using supertest.

/to: @ritch
/cc: @Schoonology @raymondfeng 

Few notes:
- This is a major change of the order in which middleware is registered.
- It requires strongloop/loopback#70
- The change has merge conflicts with #16. The test for the bugfix in that PR is skipped for now.
