### PR TITLE
Fix empty swagger descriptor

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -19,7 +19,15 @@ if(clusterOptions.clustered && clusterOptions.isMaster) {
 }
 
 /*
- * 1. Configure request preprocessing
+ * 1. Configure LoopBack models and datasources
+ *
+ * Read more at http://apidocs.strongloop.com/loopback#appbootoptions
+ */
+
+app.boot(__dirname);
+
+/*
+ * 2. Configure request preprocessing
  *
  *  LoopBack support all express-compatible middleware.
  */
@@ -37,7 +45,7 @@ app.use(loopback.methodOverride());
  */
 
 /*
- * 2. Setup request handlers.
+ * 3. Setup request handlers.
  */
 
 // LoopBack REST interface
@@ -83,7 +91,7 @@ app.use(loopback.static(path.join(__dirname, 'public')));
 app.use(loopback.urlNotFound());
 
 /*
- * 3. Setup error handling strategy
+ * 4. Setup error handling strategy
  */
 
 /*
@@ -99,13 +107,6 @@ app.use(loopback.urlNotFound());
 // The ultimate error handler.
 app.use(loopback.errorHandler());
 
-/*
- * 4. Configure LoopBack models and datasources
- *
- * Read more at http://apidocs.strongloop.com/loopback#appbootoptions
- */
-
-app.boot(__dirname);
 
 /*
  * 5. Add a basic application status route at the root `/`.

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -39,19 +39,40 @@ describe('Generated project', function() {
   });
 
   describe('of type "mobile', function() {
+    var app;
     beforeEach(function(done) {
-      Project.createFromTemplate(SANDBOX, 'mobile', done);
+      Project.createFromTemplate(SANDBOX, 'mobile', function(err) {
+        if (err) return done(err);
+        app = require(SANDBOX);
+        done();
+      });
     });
 
-    it('starts', function(done) {
+    it('starts and servers Swagger HTML', function(done) {
       // This is a smoke test checking that the template generates
       // - a valid definition of models and datasources
       // - a valid configuration of express routes
-      var app = require(SANDBOX);
       request(app)
         .get('/explorer/')
         .expect(200)
-        .end(done);
+        .expect('Content-Type', /text\/html.*/)
+        .end(function(err, res) {
+          if (err) return done(err);
+
+          expect(res.text).to.contain('StrongLoop API Explorer');
+          done();
+        });
+    });
+
+    it('exposes swagger descriptors', function(done) {
+      request(app)
+        .get('/swagger/resources')
+        .expect(200)
+        .end(function(err, res) {
+          if (err) return done(err);
+          expect(res.body.apis).to.have.length.least(1);
+          done();
+        });
     });
   });
-})
+});


### PR DESCRIPTION
Move app.boot() before registration of loopback-explorer middleware, because the swagger definition is built at the time of middleware registration.

/to @ritch Please review.
/cc @raymondfeng @Schoonology 
