### PR TITLE
Fix loopback-explorer and swagger setup.

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -54,9 +54,11 @@ app.use(apiPath, loopback.rest());
 
 // API explorer (if present)
 var explorerPath = '/explorer';
+var explorerConfigured = false;
 try {
   var explorer = require('loopback-explorer');
   app.use(explorerPath, explorer(app, { basePath: apiPath }));
+  explorerConfigured = true;
 } catch(e){
   // ignore errors, explorer stays disabled
 }
@@ -120,7 +122,9 @@ app.get('/', loopback.status());
  * 6. Enable access control and token based authentication.
  */
 
-app.remotes().exports.swagger.requireToken = false;
+var swaggerRemote = app.remotes().exports.swagger;
+if (swaggerRemote) swaggerRemote.requireToken = false;
+
 app.enableAuth();
 
 /*
@@ -133,7 +137,7 @@ if(require.main === module) {
   require('http').createServer(app).listen(app.get('port'), app.get('host'),
     function(){
       var baseUrl = 'http://' + app.get('host') + ':' + app.get('port');
-      if (explorerPath) {
+      if (explorerConfigured) {
         console.log('Browse your REST API at %s%s', baseUrl, explorerPath);
       } else {
         console.log(


### PR DESCRIPTION
Correctly detect when loopback-explorer was not installed. Before,
the condition used to detect presence of loopback-explorer was always
evaluated as true. (Introduced by #20.)

Fix the configuration of `requireToken` for the swagger remotable,
so that it works when loopback-explorer is not installed too. (Introduced by #25.)

/to: @ritch 
/cc: @raymondfeng 
