### PR TITLE
Loopback expects loopback-datasource-juggler, but no longer requires it

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "strong-agent": "~0.2.18",
     "strong-cluster-control": "~0.2.1",
     "fs-tools": "~0.2.10",
-    "loopback-explorer": "~1.0.0"
+    "loopback-explorer": "~1.0.0",
+    "loopback-datasource-juggler": "~1.2.0"
   },
   "optionalDependencies": {
     "express": "~3.4.4",


### PR DESCRIPTION
Not sure if this change should be in loopback-workspace or in loopback.

Notice that CI is still failing, but now it is due to a failing test, not a test crashing because a `require()` failed.

/to @Schoonology @ritch @raymondfeng @bajtos 
