### PR TITLE
Allow app to be runnable with cluster

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -135,8 +135,8 @@ app.enableAuth();
  * (only if this module is the main module)
  */
 
-if(require.main === module) {
-  require('http').createServer(app).listen(app.get('port'), app.get('host'),
+app.start = function() {
+  return require('http').createServer(app).listen(app.get('port'), app.get('host'),
     function(){
       var baseUrl = 'http://' + app.get('host') + ':' + app.get('port');
       if (explorerConfigured) {
@@ -149,4 +149,8 @@ if(require.main === module) {
       console.log('LoopBack server listening @ %s%s', baseUrl, '/');
     }
   );
+}
+
+if(require.main === module) {
+  app.start();
 }

--- a/templates/package.js
+++ b/templates/package.js
@@ -1,6 +1,7 @@
 module.exports = {
   "version": "0.0.0",
   "main": "app.js",
+  "bin": "server.js",
   "scripts": {
     "start": "node app.js"
   },

--- a/templates/server.js
+++ b/templates/server.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('./').start();


### PR DESCRIPTION
app.js is designed to be the package.main, so app can be required. If
its run as the main module (`node app.js`), then it also starts up.
Those features are desired, but the conditionality of startup in app.js
means there is way to start the app when run under a supervisor such as
strongloop/strong-supervisor or unitech/pm2. To fix:
- Create a single line server.js which unconditionally starts
- Add a .bin property to package.json so the app can be globally
  installed.
- Exports the startup code as a function(`require('app.js').main` when
  app is being used as a module (so behaviour of `node server.js`
  is identical to `node app.js`).
- Remove the app.js calls to strong-agent and strong-cluster-control,
  they conflict with the supervisor's.
