### PR TITLE
Mount REST at app.restApiRoot + remove explorer basePath

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -58,7 +58,7 @@ var explorerPath = '/explorer';
 var explorerConfigured = false;
 try {
   var explorer = require('loopback-explorer');
-  app.use(explorerPath, explorer(app, { basePath: apiPath }));
+  app.use(explorerPath, explorer(app));
   explorerConfigured = true;
 } catch(e){
   // ignore errors, explorer stays disabled


### PR DESCRIPTION
- Mount REST API at app.get('restApiRoot')
- Remove `basePath` option from loopback-explorer initialisation, as the plugin already uses `app.get('restApiRoot')` by default.

Requires strongloop/loopback-explorer#10.

/to: @ritch please review.
