### PR TITLE
Use `app.listen`, add "started" event, simplify explorer integration

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -54,14 +54,16 @@ app.use(loopback.methodOverride());
 app.use(app.get('restApiRoot'), loopback.rest());
 
 // API explorer (if present)
-var explorerPath = '/explorer';
-var explorerConfigured = false;
 try {
-  var explorer = require('loopback-explorer');
-  app.use(explorerPath, explorer(app));
-  explorerConfigured = true;
+  var explorer = require('loopback-explorer')(app);
+  app.use('/explorer', explorer);
+  app.once('started', function(baseUrl) {
+    console.log('Browse your REST API at %s%s', baseUrl, explorer.route);
+  });
 } catch(e){
-  // ignore errors, explorer stays disabled
+  console.log(
+    'Run `npm install loopback-explorer` to enable the LoopBack explorer'
+  );
 }
 
 /*
@@ -137,13 +139,7 @@ app.enableAuth();
 app.start = function() {
   return app.listen(function() {
     var baseUrl = 'http://' + app.get('host') + ':' + app.get('port');
-    if (explorerConfigured) {
-      console.log('Browse your REST API at %s%s', baseUrl, explorerPath);
-    } else {
-      console.log(
-        'Run `npm install loopback-explorer` to enable the LoopBack explorer'
-      );
-    }
+    app.emit('started', baseUrl);
     console.log('LoopBack server listening @ %s%s', baseUrl, '/');
   });
 };


### PR DESCRIPTION
Depends on strongloop/loopback#124
Related to #34, especially see [this comment](https://github.com/strongloop/loopback-workspace/issues/34#issuecomment-31818533).

This patch is not the ultimate solution, consider it as the first of many steps required to get where we want be with the app.js template.

/to @ritch please review
/cc @sam-github 
