### PR TITLE
Remove strong-agent and strong-cluster-control

### DIFF
--- a/templates/app.js
+++ b/templates/app.js
@@ -3,21 +3,6 @@ var path = require('path');
 var app = module.exports = loopback();
 var started = new Date();
 
-// operational dependencies
-try {
-  require('strong-agent').profile();
-  var control = require('strong-cluster-control');
-  var clusterOptions = control.loadOptions();
-} catch(e) {
-  console.log('Could not load operational dependencies:');
-  console.log(e);
-}
-
-// if configured as a cluster master, just start controller
-if(clusterOptions.clustered && clusterOptions.isMaster) {
-  return control.start(clusterOptions);
-}
-
 /*
  * 1. Configure LoopBack models and datasources
  *

--- a/templates/package.js
+++ b/templates/package.js
@@ -9,8 +9,6 @@ module.exports = {
     "loopback": "1.5.x"
   },
   "optionalDependencies": {
-    "strong-cluster-control": "~0.1.0",
-    "strong-agent": "~0.2.15",
     "loopback-explorer": "~1.1.0",
     "loopback-push-notification": "~1.1.0"
   }


### PR DESCRIPTION
Run loopback under strong-supervisor to use agent and clustering.

Would like a LGTM, but depends on release of strong-supervisor before it can be merged.

See SLN-680
