### PR TITLE
acl-definition: use loopback.ACL as the base

### DIFF
--- a/models.json
+++ b/models.json
@@ -87,27 +87,8 @@
   },
   "acl-definition": {
     "dataSource": "db",
-    "properties": {
-      "accessType": {
-        "type": "string",
-        "required": true
-      },
-      "permission": {
-        "type": "string",
-        "required": true
-      },
-      "principalType": {
-        "type": "string",
-        "required": true
-      },
-      "principalId": {
-        "type": "string",
-        "required": true
-      },
-      "property": {
-        "type": "string",
-        "required": false
-      }
+    "options": {
+      "base": "ACL"
     }
   }
 }

--- a/models/acl-definition.js
+++ b/models/acl-definition.js
@@ -1,5 +1,6 @@
 var app = require('../');
 var AclDefinition = app.models.AclDefinition;
+var ACL = require('loopback').ACL;
 
 /**
  * Convert an AclDefinition to a JSON-like object to be used in
@@ -22,10 +23,10 @@ AclDefinition.prototype.toConfig = function(cb) {
  * @type {{name: string, value: string}[]}
  */
 AclDefinition.accessTypeValues = [
-  { name: 'All (match all types)', value: '*' },
-  { name: 'Read', value: 'READ' },
-  { name: 'Write', value: 'WRITE' },
-  { name: 'Execute', value: 'EXECUTE'},
+  { name: 'All (match all types)', value: ACL.ALL },
+  { name: 'Read', value: ACL.READ },
+  { name: 'Write', value: ACL.WRITE },
+  { name: 'Execute', value: ACL.EXECUTE },
 ];
 
 /**
@@ -52,8 +53,8 @@ AclDefinition.builtinRoleValues = [
  * @type {{name: string, value: string}[]}
  */
 AclDefinition.permissionValues = [
-  { name: 'Explicitly grant access', value: 'ALLOW' },
-  { name: 'Explicitly deny access', value: 'DENY' },
-  { name: 'Generate an alarm of the access', value: 'ALARM' },
-  { name: 'Log the access', value: 'AUDIT' },
+  { name: 'Explicitly grant access', value: ACL.ALLOW },
+  { name: 'Explicitly deny access', value: ACL.DENY },
+  { name: 'Generate an alarm of the access', value: ACL.ALARM },
+  { name: 'Log the access', value: ACL.AUDIT },
 ];


### PR DESCRIPTION
Modify `AclDefinition` to inherit from `loopback.ACL`. Modify value providers to use ACL constants (e.g. `ACL.READ`).

This is a follow-up pull request for #48.

/to @ritch please review
