### PR TITLE
Implement the discovery API

### DIFF
--- a/test/data-source-definition.js
+++ b/test/data-source-definition.js
@@ -1,5 +1,8 @@
+var util = require('util');
 var async = require('async');
 var app = require('../app');
+var loopback = require('loopback');
+var DataSource = loopback.DataSource;
 var ConfigFile = app.models.ConfigFile;
 var DataSourceDefinition = app.models.DataSourceDefinition;
 var ComponentDefinition = app.models.ComponentDefinition;
@@ -50,33 +53,33 @@ describe('DataSourceDefinition', function() {
     });
   });
 
- it('validates `name` uniqueness within the component only', function(done) {
-  var ref = TestDataBuilder.ref;
-  new TestDataBuilder()
-    .define('component1', ComponentDefinition, {
-      name: 'component1'
-    })
-    .define('component2', ComponentDefinition, {
-      name: 'component2'
-    })
-    .define('component1datasource', DataSourceDefinition, {
-      name: 'dsname',
-      componentName: ref('component1.name'),
-      connector: 'foo'
-    })
-    .define('component2datasource', DataSourceDefinition, {
-      name: ref('component1datasource.name'),
-      componentName: ref('component2.name'),
-      connector: 'foo'
-    })
-    .buildTo({}, function(err) {
-      if (err && err.name === 'ValidationError') {
-        err.message += '\nDetails: ' +
-          JSON.stringify(err.details.messages, null, 2);
-      }
-      // The test passes when no error was reported.
-      done(err);
-    });
+  it('validates `name` uniqueness within the component only', function(done) {
+    var ref = TestDataBuilder.ref;
+    new TestDataBuilder()
+      .define('component1', ComponentDefinition, {
+        name: 'component1'
+      })
+      .define('component2', ComponentDefinition, {
+        name: 'component2'
+      })
+      .define('component1datasource', DataSourceDefinition, {
+        name: 'dsname',
+        componentName: ref('component1.name'),
+        connector: 'foo'
+      })
+      .define('component2datasource', DataSourceDefinition, {
+        name: ref('component1datasource.name'),
+        componentName: ref('component2.name'),
+        connector: 'foo'
+      })
+      .buildTo({}, function(err) {
+        if (err && err.name === 'ValidationError') {
+          err.message += '\nDetails: ' +
+            JSON.stringify(err.details.messages, null, 2);
+        }
+        // The test passes when no error was reported.
+        done(err);
+      });
   });
 
   describe('dataSourceDefinition.configFile', function () {
@@ -90,15 +93,52 @@ describe('DataSourceDefinition', function() {
     });
   });
 
-  describe.skip('dataSourceDefinition.testConnection(callback)', function() {
-    it('Test the datasource definition connection.', function(done) {
-
+  describe('dataSourceDefinition.toDataSource()', function () {
+    it('should get an actual dataSource object', function () {
+      var dataSourceDef = new DataSourceDefinition({
+        connector: 'memory',
+        name: 'db'
+      });
+      expect(dataSourceDef.toDataSource()).to.be.an.instanceof(DataSource);
     });
   });
 
-  describe.skip('dataSourceDefinition.getSchema(name, callback)', function() {
-    it('Get the schema for the given table / collection name.', function(done) {
+  describe('dataSourceDefinition.testConnection(callback)', function() {
+    it('Test the datasource definition connection.', function(done) {
+      var dataSourceDef = getMockDataSourceDef();
 
+      dataSourceDef.testConnection(function(err, connectionAvailable) {
+        expect(err).to.not.exist;
+        expect(connectionAvailable).to.be.true;
+        done();
+      });
+    });
+  });
+
+  describe('dataSourceDefinition.getSchema(callback)', function() {
+    it('Test the datasource definition connection.', function(done) {
+      var dataSourceDef = getMockDataSourceDef();
+
+      dataSourceDef.getSchema({}, function(err, schema) {
+        expect(err).to.not.exist;
+        expect(schema).to.be.instanceof(Array);
+        done();
+      });
+    });
+  });
+
+  describe('dataSourceDefinition.discoverModelDefinition(name, callback)', function() {
+    it('Test the datasource definition connection.', function(done) {
+      var dataSourceDef = getMockDataSourceDef();
+
+      dataSourceDef.getSchema({}, function(err, schema) {
+        expect(err).to.not.exist;
+        dataSourceDef.discoverModelDefinition(schema[0].name, {}, function(err, schema) {
+          expect(err).to.not.exist;
+          expect(schema.Customer).to.exist;
+          done();
+        });
+      });
     });
   });
 
@@ -115,3 +155,78 @@ describe('DataSourceDefinition', function() {
     });
   });
 });
+
+function getMockDataSourceDef() {
+  var def = new DataSourceDefinition({
+    connector: 'memory',
+    name: 'db'
+  });
+
+  var dataSource = def.toDataSource();
+
+  var mockDataSource = {
+    connector: {
+      connect: function(cb) {
+        process.nextTick(cb);
+      }
+    },
+    discoverModelDefinitions: function(options, cb) {
+      cb(null,
+        [
+          { type: 'table', name: 'customer', schema: 'strongloop' },
+          { type: 'table', name: 'inventory', owner: 'strongloop' },
+          { type: 'table', name: 'location', schema: 'strongloop' },
+          { type: 'table', name: 'session', owner: 'strongloop' },
+          { type: 'view', name: 'INVENTORY_VIEW', owner: 'STRONGLOOP' }
+        ]
+      );
+    },
+    discoverSchemas: function(modelName, options, cb) {
+      cb(null, {
+        "Customer": {
+          "options": {
+            "idInjection": false,
+            "oracle": {
+              "schema": "BLACKPOOL",
+              "table": "PRODUCT"
+            },
+            "relations": {
+              // TODO(ritch) add relations
+            }
+          },
+          "properties": {
+            "id": {
+              "type": "String",
+              "required": true,
+              "length": 20,
+              "id": 1,
+              "oracle": {
+                "columnName": "ID",
+                "dataType": "VARCHAR2",
+                "dataLength": 20,
+                "nullable": "N"
+              }
+            },
+            "name": {
+              "type": "String",
+              "required": false,
+              "length": 64,
+              "oracle": {
+                "columnName": "NAME",
+                "dataType": "VARCHAR2",
+                "dataLength": 64,
+                "nullable": "Y"
+              }
+            }
+          }
+        }
+      });
+    }
+  };
+
+  def.toDataSource = function() {
+    return util._extend(dataSource, mockDataSource);
+  }
+
+  return def;
+}


### PR DESCRIPTION
/to @bajtos @raymondfeng 

This adds discovery support to the workspace. The methods are not remoted yet, but that will come in a PR that adds remoting to all custom methods.

I'm not sure about how this is currently tested, since it uses a mock data source. But I'm also not convinced yet that taking on the burden of running actual end to end discovery would make sense either. Any suggestions here would be helpful.
