### PR TITLE
Only clear the loader once loadFromFile is complete

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -31,6 +31,8 @@ connector.loadFromFile = function() {
       loader.emit('error', err);
     else
       loader.emit('complete');
+
+    connector.loader = null;
     cb(err);
   };
 
@@ -52,7 +54,6 @@ connector.loadFromFile = function() {
         }
         // commit the cache
         connector.cache = cache;
-        connector.loader = null;
         if(debug.enabled) {
           Object.keys(cache).forEach(function(model) {
             debug('setting cache %s => %j', model, Object.keys(cache[model]));


### PR DESCRIPTION
/to @bajtos 

This just ensures the loader is reset once loading from disk is complete.

A brief background on why we need the loader:
- if `loadFromFile` is called twice in the same tick, the resulting cache of the second load although atomic, will destroy the cache from the previous call. This sounds like it should be fine, but since `create` can call `find() (via uniqueness validation) there is a potential for the cache to be populated multiple times after`create` has already added correct data that won't exist on disk...

The loader prevents this by only allowing a single `loadFromFile()` to occur at a time... This should be fine for most practical cases. I can think of edge cases where the disk changes during the two calls, but I'm not so concerned about that. If you have any ideas for a better fix I am glad to hear them.
