### PR TITLE
Add ModelProperty.isId

### DIFF
--- a/models.json
+++ b/models.json
@@ -227,6 +227,7 @@
       "modelId": {"type": "string", "required": true},
       "type": {"type": "string"},
       "name": {"type": "string"},
+      "isId": {"type": "boolean", "json": "id"},
       "generated": {"type": "boolean"},
       "required": {"type": "boolean"},
       "index": {"type": "boolean"},

--- a/models/definition.js
+++ b/models/definition.js
@@ -110,7 +110,7 @@ Definition.addRelatedToCache = function(cache, fileData, componentName, fk) {
   this.getEmbededRelations().forEach(function(relation) {
     var relatedData = fileData[relation.as];
     var Entity = loopback.getModel(relation.model);
-    var entity;
+    var properties = Entity.definition.properties;
 
     if(Array.isArray(relatedData)) {
       relatedData.forEach(function(config) {
@@ -122,6 +122,17 @@ Definition.addRelatedToCache = function(cache, fileData, componentName, fk) {
     } else if(relatedData) {
       Object.keys(relatedData).forEach(function(embedId) {
         var config = relatedData[embedId];
+
+        // apply `json` config from LDL property definitions
+        Object.keys(properties).forEach(function(p) {
+          var json = properties[p].json;
+          if (json) {
+            config[p] = config[json];
+            delete config[json];
+          }
+        });
+
+        // add extra properties for relations
         config[relation.foreignKey] = fk;
         config[relation.embed.key] = embedId;
         config.componentName = componentName;

--- a/models/model-definition.js
+++ b/models/model-definition.js
@@ -93,6 +93,8 @@ ModelDefinition.toFilename = function(name) {
  */
 
 function cleanRelatedData(relatedData, relation) {
+  var Entity = require('loopback').getModel(relation.model);
+  var properties = Entity.definition.properties;
   relatedData.forEach(function(obj) {
     assert(relation.foreignKey, 'embeded relation must have foreignKey');
     delete obj[relation.foreignKey];    
@@ -101,5 +103,14 @@ function cleanRelatedData(relatedData, relation) {
     delete obj.id;
     delete obj.componentName;
     delete obj.modelName;
+
+    // apply `json` config from LDL property definitions
+    Object.keys(properties).forEach(function(p) {
+      var json = properties[p].json;
+      if (json) {
+        obj[json] = obj[p];
+        delete obj[p];
+      }
+    });
   });
 }

--- a/test/model-property.js
+++ b/test/model-property.js
@@ -18,6 +18,7 @@ describe('ModelProperty', function() {
     var property = {
       name: test.propertyName,
       type: 'String',
+      isId: false,
       modelId: 'rest.user'
     };
     ModelProperty.create(property, function(err, property) {
@@ -34,7 +35,7 @@ describe('ModelProperty', function() {
       var type = this.property.type;
       expect(this.property.name).to.equal(this.propertyName);
       expect(properties).to.have.property(this.propertyName);
-      expect(properties[this.propertyName]).to.eql({type: type});
+      expect(properties[this.propertyName]).to.eql({type: type, id: false});
     });
     it('should have the correct id', function () {
       expect(this.property.id).to.equal('rest.user.myProperty');
@@ -65,12 +66,13 @@ describe('ModelProperty', function() {
   describe('model.save()', function () {
     beforeEach(function(done) {
       this.property.type = 'Boolean';
+      this.property.isId = true;
       this.property.save(done);
     });
     beforeEach(givenFile('configFile', 'rest/models/user.json'));
     it('should update the $modelName.json file', function () {
       var properties = this.configFile.data.properties;
-      expect(properties[this.propertyName]).to.eql({type: 'Boolean'});
+      expect(properties[this.propertyName]).to.eql({type: 'Boolean', id: true});
     });
   });
 
@@ -83,6 +85,7 @@ describe('ModelProperty', function() {
         var expected = new ModelProperty({
           name: this.propertyName,
           type: 'String',
+          isId: false,
           componentName: 'rest',
           id: 'rest.user.myProperty',
           modelId: 'rest.user'


### PR DESCRIPTION
Add `ModelProperty.isId` that is serialized as `id: bool` in `models.json`:

``` js
{
  "name": "Car",
  "properties": {
    "id": {
      "type": "string",
      "id": true, // <-- added by this patch
      "generated": true
   }
}
```

Implement support for LDL annotation allowing entity properties to specify a different name to use when serializing to config JSON.

/to @ritch please review
