### PR TITLE
test: use strong-cached-install in e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "grunt-loopback-angular": "~1.1.0",
     "loopback-testing": "^0.2.0",
     "mocha": "^1.20.1",
+    "strong-cached-install": "^1.0.0",
     "supertest": "^0.13.0"
   }
 }


### PR DESCRIPTION
/cc @ritch FYI. I decided to refactor out the caching `npm install` into a standalone module. That way we can use it in generator-loopback too.
