### PR TITLE
Remove `configFile` from datasources.json

### DIFF
--- a/models/component-definition.js
+++ b/models/component-definition.js
@@ -202,6 +202,7 @@ ComponentDefinition.saveToFs = function(cache, componentDef, cb) {
         delete dataSourceDef.name;
         delete dataSourceDef.id;
         delete dataSourceDef.componentName;
+        delete dataSourceDef.configFile;
       }
     });
 

--- a/test/data-source-definition.js
+++ b/test/data-source-definition.js
@@ -55,10 +55,29 @@ describe('DataSourceDefinition', function() {
         expect(dsConfig).to.not.have.property('componentName');
       });
     });
-    it('shoulb be persist multiple to the config file', function (done) {
+    it('should persist multiple entities to the config file', function (done) {
       var defs = Object.keys(this.configFile.data).sort();
       expect(defs).to.eql(['bar', 'foo'].sort());
       done();
+    });
+
+    it('should not contain workspace-private properties', function(done) {
+      // This test is reproducing an issue discovered in generator-loopback
+
+      var configFile = this.configFile;
+      DataSourceDefinition.create({
+        name: 'another-ds',
+        connector: 'rest',
+        componentName: this.emptyComponent
+      }, function(err) {
+        if (err) return done(err);
+        configFile.load(function(err) {
+          if (err) done(err);
+          var datasources = configFile.data;
+          expect(Object.keys(datasources.foo)).to.not.contain('configFile');
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Fix the code generating datasources.json to omit the workspace-private property `configFile`.

The current implementation of loading/saving is rather difficult to test. It would be great to refactor it for better testability some day, but that's out of scope of this pull request.

/to @ritch please review
