### PR TITLE
Fix order of keys in JSON files

### DIFF
--- a/models.json
+++ b/models.json
@@ -16,7 +16,7 @@
   },
   "PackageDefinition": {
     "properties": {
-      "componentName": {"type": "string", "required": true},
+      "componentName": {"type": "string", "required": true, "json": false},
       "name": {"id": true, "type": "string"}
     },
     "public": false,
@@ -31,8 +31,8 @@
   },
   "ComponentDefinition": {
     "properties": {
-      "name": {"id": true, "type": "string"},
-      "modelsMetadata": "object",
+      "name": {"id": true, "type": "string", "json": false},
+      "modelsMetadata": {"type": "object", "json": false},
       "defaultPermission": {"type": "string"}
     },
     "public": true,
@@ -65,9 +65,9 @@
   },
   "ComponentModel": {
     "properties": {
-      "id": {"type": "string", "id": true},
-      "name": {"type": "string"},
-      "componentName": {"type": "string", "required": true}
+      "id": {"type": "string", "id": true, "json": false},
+      "componentName": {"type": "string", "required": true, "json": false},
+      "name": {"type": "string", "json": false}
     },
     "dataSource": "db",
     "options": {
@@ -95,15 +95,16 @@
   },
   "ModelDefinition": {
     "properties": {
-      "id": {"type": "string", "id": true},
+      "id": {"type": "string", "id": true, "json": false},
+      "componentName": {"type": "string", "required": true, "json": false},
       "name": {"type": "string", "required": true},
       "plural": "string",
-      "strict": "boolean",
       "base": "string",
-      "scopes": "array",
+      "strict": "boolean",
       "public": "boolean",
+      "idInjection": "boolean",
+      "scopes": "array",
       "indexes": "array",
-      "componentName": {"type": "string", "required": true},
       "options": "object"
     },
     "public": true,
@@ -162,8 +163,9 @@
   },
   "ModelMethod": {
     "properties": {
-      "id": {"type": "string", "id": true},
-      "modelId": {"type": "string", "required": true},
+      "id": {"type": "string", "id": true, "json": false},
+      "modelId": {"type": "string", "required": true, "json": false},
+      "componentName": {"type": "string", "required": true, "json": false},
       "aliases": {"type": "array"},
       "isStatic": {"type": "boolean"},
       "accepts": {"type": "array"},
@@ -180,12 +182,13 @@
   },
   "ModelRelation": {
     "properties": {
-      "id": {"type": "string", "id": true},
-      "modelId": {"type": "string", "required": true},
+      "id": {"type": "string", "id": true, "json": false},
+      "modelId": {"type": "string", "required": true, "json": false},
+      "componentName": {"type": "string", "required": true, "json": false},
       "type": {"type": "string"},
+      "model": {"type": "string"},
       "as": {"type": "string"},
-      "foreignKey": {"type": "string"},
-      "model": {"type": "string"}
+      "foreignKey": {"type": "string"}
     },
     "public": true,
     "dataSource": "db",
@@ -202,13 +205,14 @@
   },
   "ModelAccessControl": {
     "properties": {
-      "id": {"type": "string", "id": true},
-      "modelId": {"type": "string", "required": true},
-      "property": {"type": "string"},
-      "route": {"type": "string"},
-      "principalId": {"type": "string"},
+      "id": {"type": "string", "id": true, "json": false},
+      "modelId": {"type": "string", "required": true, "json": false},
+      "componentName": {"type": "string", "required": true, "json": false},
       "principalType": {"type": "string"},
-      "permission": {"type": "string", "required": true}
+      "principalId": {"type": "string"},
+      "permission": {"type": "string", "required": true},
+      "property": {"type": "string"},
+      "route": {"type": "string"}
     },
     "public": true,
     "dataSource": "db",
@@ -225,10 +229,11 @@
   },
   "ModelProperty": {
     "properties": {
-      "id": {"type": "string", "id": true},
-      "modelId": {"type": "string", "required": true},
-      "type": {"type": "string"},
+      "id": {"type": "string", "id": true, "json": false},
+      "modelId": {"type": "string", "required": true, "json": false},
+      "componentName": {"type": "string", "required": true, "json": false},
       "name": {"type": "string"},
+      "type": {"type": "string"},
       "isId": {"type": "boolean", "json": "id"},
       "generated": {"type": "boolean"},
       "required": {"type": "boolean"},
@@ -269,8 +274,8 @@
   },
   "PropertyValidation": {
     "properties": {
-      "id": {"type": "string", "id": true},
-      "propertyId": {"type": "string", "required": true},
+      "id": {"type": "string", "id": true, "json": false},
+      "propertyId": {"type": "string", "required": true, "json": false},
       "type": {"type": "string"},
       "message": {"type": "string"},
       "min": {"type": "number"},
@@ -316,14 +321,14 @@
   },
   "DataSourceDefinition": {
     "properties": {
-      "id": {"type": "string", "id": true},
+      "id": {"type": "string", "id": true, "json": false},
       "host": {"type": "string"},
       "port": {"type": "number"},
       "url": {"type": "string"},
       "database": {"type": "string"},
       "username": {"type": "string"},
       "password": {"type": "string"},
-      "componentName": {"type": "string", "required": true}
+      "componentName": {"type": "string", "required": true, "json": false}
     },
     "public": true,
     "dataSource": "db",
@@ -337,7 +342,7 @@
       "relations": {
         "models": {
           "type": "hasMany",
-          "model": "ModelDefinition",
+          "model": "ComponentModel",
           "foreignKey": "dataSource"
         },
         "component": {

--- a/models/component-definition.js
+++ b/models/component-definition.js
@@ -169,12 +169,7 @@ ComponentDefinition.saveToFs = function(cache, componentDef, cb) {
 
   if (hasApp) {
     var configFile = ComponentDefinition.getConfigFile(componentName, componentDef);
-    var data = require('util')._extend({}, componentDef);
-    // remove extra data that shouldn't be persisted to the fs
-    delete data.configFile;
-    delete data.name;
-    delete data.modelsMetadata;
-    configFile.data = data;
+    configFile.data = ComponentDefinition.getConfigFromData(componentDef);
 
     filesToSave.push(configFile);
   }
@@ -198,10 +193,8 @@ ComponentDefinition.saveToFs = function(cache, componentDef, cb) {
     cachedDataSources.forEach(function(dataSourceDef) {
       if(dataSourceDef.componentName === componentName) {
         dataSourcePath = DataSourceDefinition.getPath(componentName, dataSourceDef);
-        dataSoureConfig[dataSourceDef.name] = dataSourceDef;
-        delete dataSourceDef.name;
-        delete dataSourceDef.id;
-        delete dataSourceDef.componentName;
+        dataSoureConfig[dataSourceDef.name] =
+          DataSourceDefinition.getConfigFromData(dataSourceDef);
       }
     });
 
@@ -219,10 +212,8 @@ ComponentDefinition.saveToFs = function(cache, componentDef, cb) {
 
     cachedComponentModels.forEach(function(componentModel) {
       if(componentModel.componentName === componentName) {
-        componentModelsConfig[componentModel.name] = componentModel;
-        delete componentModel.name;
-        delete componentModel.id;
-        delete componentModel.componentName;
+        componentModelsConfig[componentModel.name] =
+          ComponentModel.getConfigFromData(componentModel);
       }
     });
 
@@ -235,7 +226,7 @@ ComponentDefinition.saveToFs = function(cache, componentDef, cb) {
     debug('model definition ~ %j', modelDef);
     if(modelDef.componentName === componentName) {
       var modelConfigFile = ModelDefinition.getConfigFile(componentName, modelDef);
-      modelConfigFile.data = ModelDefinition.getConfigData(cache, modelDef);
+      modelConfigFile.data = ModelDefinition.getConfigFromCache(cache, modelDef);
       filesToSave.push(modelConfigFile);
     }
   });

--- a/models/definition.js
+++ b/models/definition.js
@@ -19,7 +19,8 @@ var Definition = app.model('Definition', {
     },
     "dir": {
       "type": "string",
-      "desc": "the directory name where the definition is persisted"
+      "desc": "the directory name where the definition is persisted",
+      "json": false
     }
   },
   "public": false,

--- a/test/data-source-definition.js
+++ b/test/data-source-definition.js
@@ -60,8 +60,25 @@ describe('DataSourceDefinition', function() {
       expect(defs).to.eql(['bar', 'foo'].sort());
       done();
     });
-  });
 
+    it('should not contain workspace-private properties', function(done) {
+      // This test is reproducing an issue discovered in generator-loopback
+      var configFile = this.configFile;
+      DataSourceDefinition.create({
+        name: 'another-ds',
+        connector: 'rest',
+        componentName: this.emptyComponent
+      }, function(err) {
+        if (err) return done(err);
+        configFile.load(function(err) {
+          if (err) done(err);
+          var datasources = configFile.data;
+          expect(Object.keys(datasources.foo)).to.not.contain('configFile');
+          done();
+        });
+      });
+    });
+  });
   it('validates `name` uniqueness within the component only', function(done) {
     var ref = TestDataBuilder.ref;
     new TestDataBuilder()


### PR DESCRIPTION
Implement a new method `WorkspaceEntity.getConfigFromData` that converts
the Entity data from connector cache into an object that has properties
ordered in the same way as the Entity properties are ordered in the
Entity LDL definition.

Extend the semantics of the property flag `json`: when the value is
`false`, the property is not written to the JSON config file.

Use these two mechanism in all relevant places to ensure that
JSON config files contain only the relevant keys and the order of these
keys is always the same.

Add an internal `componentName` property to embedded Model\* entities.
Implement a hook in WorkspaceEntity to automatically fill
the `componentName` property from the parent model.

/to @raymondfeng please review
/cc @ritch 
