### PR TITLE
[3.0] templates: fixate loopback-boot version

### DIFF
--- a/templates/api-server/component.js
+++ b/templates/api-server/component.js
@@ -17,7 +17,7 @@ template.package = {
     "compression": "^1.0.3",
     "errorhandler": "^1.1.1",
     "loopback": "~2.0.0-beta5",
-    "loopback-boot": "~2.0.0-beta1",
+    "loopback-boot": "2.0.0-beta1",
     "loopback-datasource-juggler": "~2.0.0-beta2"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Prevent `npm install` from using 2.0.0-beta2, which is not compatible
with 2.0.0-beta1.
