### PR TITLE
[3.0] Use the package 'method-override'

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 var loopback = require('loopback');
 var path = require('path');
+var methodOverride = require('method-override');
 var app = module.exports = loopback();
 var boot = require('loopback-boot');
 var started = new Date();
@@ -39,7 +40,7 @@ app.use(loopback.favicon());
 app.use(loopback.logger(app.get('env') === 'development' ? 'dev' : 'default'));
 app.use(loopback.cookieParser(app.get('cookieSecret')));
 app.use(loopback.token({model: app.models.accessToken}));
-app.use(loopback.methodOverride());
+app.use(methodOverride());
 
 /*
  * EXTENSION POINT

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "grunt-docular": "~0.1.2",
     "grunt-loopback-angular": "~1.1.0",
     "loopback-testing": "^0.2.0",
+    "method-override": "^2.1.1",
     "mocha": "^1.20.1",
     "strong-cached-install": "^1.0.0",
     "supertest": "^0.13.0"


### PR DESCRIPTION
Replace `loobpack.methodOverride()` with using `method-override`
directly in order to prevent a warning from connect.

```
connect deprecated methodOverride: use method-override module directly app.js:42:18
```

/to @ritch please review

I am not sure if this should be fixed here, or rather in loopback 1.x. `loopback 2.x` already has a code to expose 'method-override' as `loopback.methodOverride`, perhaps we can back-port it to 1.x

Thoughts?

/cc @raymondfeng 
