### PR TITLE
Add `baseModel` to connector metadata

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -2,52 +2,62 @@
   {
     "name": "memory",
     "description": "In-memory db",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": true
   },
   {
     "name": "mysql",
     "description": "MySQL",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": true
   },
   {
     "name": "postgresql",
     "description": "PostgreSQL",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": true
   },
   {
     "name": "oracle",
     "description": "Oracle",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": true
   },
   {
     "name": "mssql",
     "description": "Microsoft SQL",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": true
   },
   {
     "name": "mongodb",
     "description": "MongoDB",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": true
   },
   {
     "name": "soap",
     "description": "SOAP webservices",
+    "baseModel": "Model",
     "supportedByStrongLoop": true
   },
   {
     "name": "rest",
     "description": "REST services",
+    "baseModel": "Model",
     "supportedByStrongLoop": true
   },
 
   {
     "name": "neo4j",
     "description": "Neo4j",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": false
   },
   {
     "name": "kafka",
     "description": "Kafka",
+    "baseModel": "PersistedModel",
     "supportedByStrongLoop": false
   }
 ]

--- a/test/workspace.js
+++ b/test/workspace.js
@@ -94,17 +94,29 @@ describe('Workspace', function() {
   });
 
   describe('project.listAvailableConnectors(cb)', function() {
+    var connectors;
     before(function(done) {
       Workspace.listAvailableConnectors(function(err, list) {
-        this.connectors = list;
+        connectors = list;
         done(err);
-      }.bind(this));
+      });
     });
 
     it('should include Memory connector', function() {
-      var names = this.connectors.map(function(it) { return it.name; });
+      var names = connectors.map(function(it) { return it.name; });
       expect(names).to.contain('memory');
     });
+
+    it('should include base model in metadata', function() {
+      var meta = findByName('memory');
+      expect(meta).to.have.property('baseModel', 'PersistedModel');
+    });
+
+    function findByName(name) {
+      return connectors.filter(function(c) {
+        return c.name === name;
+      })[0];
+    }
   });
 
   describe('Workspace.isValidDir(cb)', function() {


### PR DESCRIPTION
This patch enables `yo loopback:model` to set the correct base class depending on the datasource the model is attached to.

/to @raymondfeng please review
/cc @ritch 
