### PR TITLE
api-server template: add dot files

### DIFF
--- a/templates/api-server/component.js
+++ b/templates/api-server/component.js
@@ -7,6 +7,9 @@ var template = module.exports;
 template.package = {
   "version": "0.0.0",
   "main": "server/server.js",
+  "scripts": {
+    "pretest": "jshint .",
+  },
   "dependencies": {
     "compression": "^1.0.3",
     "errorhandler": "^1.1.1",

--- a/templates/api-server/template/.editorconfig
+++ b/templates/api-server/template/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/templates/api-server/template/.gitignore
+++ b/templates/api-server/template/.gitignore
@@ -1,0 +1,16 @@
+.idea
+.project
+*.sublime-*
+.DS_Store
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.swp
+*.swo
+node_modules
+coverage
+*.tgz
+*.xml

--- a/templates/api-server/template/.jshintignore
+++ b/templates/api-server/template/.jshintignore
@@ -1,0 +1,2 @@
+/client/
+/node_modules/

--- a/templates/api-server/template/.jshintrc
+++ b/templates/api-server/template/.jshintrc
@@ -1,0 +1,21 @@
+{
+  "node": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "eqeqeq": true,
+  "eqnull": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": "nofunc",
+  "newcap": true,
+  "nonew": true,
+  "noarg": true,
+  "quotmark": "single",
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "trailing": true,
+  "sub": true,
+  "maxlen": 80
+}

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -112,6 +112,32 @@ describe('end-to-end', function() {
         }
       ], done);
     });
+
+    it('passes scaffolded tests', function(done) {
+      execNpm(['test'], { cwd: SANDBOX }, function(err, stdout, stderr) {
+        done(err);
+      });
+    });
   });
 });
 
+function execNpm(args, options, cb) {
+  var debug = require('debug')('test:exec-npm');
+  options = options || {};
+  options.env = extend(
+    {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
+    },
+    options.env
+  );
+
+  var command = 'npm ' + args.join(' ');
+  debug(command);
+  return exec(command, options, function(err, stdout, stderr) {
+    debug('--npm stdout--\n%s\n--npm stderr--\n%s\n--end--',
+      stdout, stderr);
+    cb(err, stdout, stderr);
+  });
+}


### PR DESCRIPTION
Add `.jshintrc` and `.jshintignore`, configure `npm test` to run
`jshint` before the tests.

Add `.gitignore` with the usual set of files that should be excluded
from git.

Add `.editorconfig` with some basic editor settings matching the coding
style used in the template.

See SLA-839 for background info.

/to @ritch @sam-github please review
/cc @raymondfeng 
