### PR TITLE
Add test for creating datasources over REST

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,9 +6,6 @@ var boot = require('loopback-boot');
 var started = new Date();
 var env = app.get('env');
 
-// long stack traces
-require('longjohn');
-
 // required to support base models
 app.dataSource('db', {
   connector: loopback.Memory,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "glob": "~4.0.2",
     "grunt": "~0.4.5",
     "grunt-loopback-angular": "~1.1.0",
-    "longjohn": "~0.2.4",
     "loopback": "^2.0.0",
     "loopback-datasource-juggler": "^2.0.0",
     "loopback-boot": "^1.0.0",

--- a/test/rest.js
+++ b/test/rest.js
@@ -50,6 +50,7 @@ describe('REST API', function () {
     });
 
     describe('POST /workspaces/connectors', function () {
+      beforeEach(givenEmptyWorkspace);
       beforeEach(function(done) {
         this.req = request(app)
           .get('/api/workspaces/connectors')
@@ -68,6 +69,33 @@ describe('REST API', function () {
         expect(connectors).to.contain('rest');
         expect(connectors).to.contain('neo4j');
         expect(connectors).to.contain('kafka');
+      });
+    });
+
+    describe('POST /api/DataSourceDefinitions', function () {
+      beforeEach(givenEmptyWorkspace);
+      beforeEach(function(done) {
+        this.req = request(app)
+          .post('/api/DataSourceDefinitions')
+          .set('Accepts', 'application/json')
+          .send({
+            "defaultForType": "mysql",
+            "name": "test",
+            "connector": "loopback-connector-mysql",
+            "host": "demo.strongloop.com",
+            "port": 3306,
+            "facetName": "server",
+            "database": "demo",
+            "username": "demo******",
+            "password": "**********"
+          })
+          .end(done);
+      });
+      it('should create a datasource def', function (done) {
+        app.models.DataSourceDefinition.findById('server.test', function(err, def) {
+          expect(def).to.exist;
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
/to @seanbrookes 

This fixes the weird circular JSON structure error (caused by longjohn). It also adds a test for creating datasources over REST (which passes without changing anything, but uses the server facet).
