### PR TITLE
package: update fs-extra

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cookie-parser": "^1.3.2",
     "debug": "~1.0.1",
     "errorhandler": "^1.1.1",
-    "fs-extra": "~0.10.0",
+    "fs-extra": "~0.11.0",
     "glob": "~4.0.2",
     "grunt": "~0.4.5",
     "grunt-loopback-angular": "~1.1.0",


### PR DESCRIPTION
The version v0.11 fixes the issue of missing EOL at EOF when writing
a JSON file.

See also https://github.com/strongloop/generator-loopback/issues/25
