### PR TITLE
Add name validations

### DIFF
--- a/models/model-definition.js
+++ b/models/model-definition.js
@@ -25,6 +25,7 @@ var ModelDefinition = app.models.ModelDefinition;
 
 ModelDefinition.validatesUniquenessOf('name', { scopedTo: ['app'] });
 ModelDefinition.validatesPresenceOf('name');
+ModelDefinition.validatesFormatOf('name', { with: /^[\-_a-zA-Z0-9]+$/ });
 
 ModelDefinition.getConfigFromCache = function(cache, modelDef) {
   var configData = this.getConfigFromData(modelDef);

--- a/models/model-property.js
+++ b/models/model-property.js
@@ -9,6 +9,8 @@ var app = require('../app');
 
 var ModelProperty = app.models.ModelProperty;
 
+ModelProperty.validatesFormatOf('name', { with: /^[\-_a-zA-Z0-9]+$/ });
+
 /**
  * List of built-in types that can be used for `ModelProperty.type`.
  * @type {string[]}

--- a/models/package-definition.js
+++ b/models/package-definition.js
@@ -2,6 +2,8 @@ var models = require('../app').models;
 var PackageDefinition = models.PackageDefinition;
 var ConfigFile = models.ConfigFile;
 
+PackageDefinition.validatesFormatOf('name', { with: /^[\-_a-zA-Z0-9]+$/ });
+
 PackageDefinition.prototype.getUniqueId = function() {
   return this.name || null;
 }

--- a/models/workspace.js
+++ b/models/workspace.js
@@ -215,11 +215,10 @@ Workspace.createFromTemplate = function(templateName, name, cb) {
 
 loopback.remoteMethod(Workspace.createFromTemplate, {
   http: {verb: 'post', path: '/'},
-  accepts: [{
-    arg: 'templateName', type: 'string'
-  }, {
-    arg: 'name', type: 'string', http: {source: 'body'}
-  }]
+  accepts: [
+    { arg: 'templateName', type: 'string' },
+    { arg: 'name', type: 'string' }
+  ]
 });
 
 /**

--- a/test/model-definition.js
+++ b/test/model-definition.js
@@ -78,6 +78,24 @@ describe('ModelDefinition', function() {
     });
   });
 
+  describe('validation', function() {
+    before(givenBasicWorkspace);
+
+    it('rejects invalid model name', function(done) {
+      var md = new ModelDefinition({
+        facetName: 'server',
+        name: 'a name with space'
+      });
+
+      md.isValid(function(valid) {
+        expect(valid, 'isValid').to.be.false;
+        expect(md.errors).to.have.property('name');
+        expect(md.errors.name).to.eql(['is invalid']);
+        done();
+      });
+    });
+  });
+
   describe('ModelDefinition.toFilename(modelName)', function () {
     given('Foo').expect('foo');
     given('FooBar').expect('foo-bar');
@@ -163,6 +181,7 @@ describe('ModelDefinition', function() {
         new TestDataBuilder()
           .define('model', ModelDefinition, {
             facetName: this.serverFacet,
+            name: 'a-name',
             custom: true
           })
           .define('acl', ModelAccessControl, {

--- a/test/rest.js
+++ b/test/rest.js
@@ -6,7 +6,7 @@ describe('REST API', function () {
   
   describe('/workspaces', function () {
     describe('POST /workspaces', function () {
-      beforeEach(function(done) {
+      beforeEach(function createWorkspaceFromTemplate(done) {
         request(app)
           .post('/api/workspaces')
           .set('Content-Type', 'application/json')


### PR DESCRIPTION
ModelDefinition.name, PackageDefinition.name and ModelProperty.name
must not contain special characters.

Fix remoting metadata of Workspace.createFromTemplate.

/to @ritch please review
/cc @seanbrookes 
