### PR TITLE
connector: pass correct arguments to save cb

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -11,9 +11,10 @@ var EventEmitter = require('events').EventEmitter;
 connector.writeCallbacks = [];
 var debugSync = require('debug')('workspace:connector:save-sync');
 
-connector.saveToFile = function() {
-  var cb = arguments[arguments.length - 1];
-  connector.writeCallbacks.push(cb);
+connector.saveToFile = function(result, callback) {
+  connector.writeCallbacks.push(function(err) {
+    callback(err, result);
+  });
 
   if (connector.writeCallbacks.length == 1) {
     // The first write, nobody else is writing now
@@ -50,7 +51,7 @@ connector.saveToFile = function() {
     };
     cb.internal = true;
 
-    connector.saveToFile(cb);
+    connector.saveToFile(null, cb);
   }
 };
 


### PR DESCRIPTION
Before this change, `updateOrCreate` did not pass the updated object to the callback when `update` branch was executed.

`DataAccessObject.updateOrCreate` uses the updated object to construct the model returned as a result of `updateOrCreate`.

/to @ritch please review
