### PR TITLE
Preserve property order in models.json

### DIFF
--- a/models.json
+++ b/models.json
@@ -90,6 +90,7 @@
       "id": {"type": "string", "id": true, "json": false},
       "facetName": {"type": "string", "required": true, "json": false},
       "name": {"type": "string", "json": false},
+      "dataSource": {"type": "string" },
       "public": {"type": "boolean"}
     },
     "dataSource": "db",


### PR DESCRIPTION
388847 added `public` as a property to `ModelConfig`, which had an unintended side-effect of changing the order of properties in `model-config.json`. Before that change, `dataSource` came before `public`. After that change, `public` is first.

This commit fixes the problem by explicitly defining `dataSource` property in ModelConfig definition. (The property is otherwise added by "belongsTo DataSource" relation.)

See also https://github.com/strongloop/generator-loopback/issues/25.

/to @ritch please review
