### PR TITLE
Update minimum juggler version to v2.7.0

### DIFF
--- a/templates/api-server/component.js
+++ b/templates/api-server/component.js
@@ -15,7 +15,7 @@ template.package = {
     "errorhandler": "^1.1.1",
     "loopback": "^2.0.0",
     "loopback-boot": "^2.0.0",
-    "loopback-datasource-juggler": "^2.6.1",
+    "loopback-datasource-juggler": "^2.7.0",
     "serve-favicon": "^2.0.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This ensures that `dataSource.ping()` method handles connector errors
correctly. See the following GH issues for more details:

https://github.com/strongloop/strong-studio/issues/135
https://github.com/strongloop/loopback-datasource-juggler/pull/260

Close https://github.com/strongloop/strong-studio/issues/135

/to @ritch please review
