### PR TITLE
Fix missing connector message + other improvements

### DIFF
--- a/bin/datasource-invoke.js
+++ b/bin/datasource-invoke.js
@@ -20,7 +20,7 @@ try {
   console.log('Invoking %s %j', methodName, args);
   args.push(function callback(err, result) {
     if (err) {
-      reportError(err);
+      reportError('invoke', err);
       process.exit(1);
     } else {
       console.log('Done', result);
@@ -30,13 +30,14 @@ try {
 
   ds[methodName].apply(ds, args);
 } catch (err) {
-  reportError(err);
+  reportError('uncaught', err);
   process.exit(2);
 }
 
-function reportError(err) {
+function reportError(origin, err) {
   console.error('--datasource-invoke-error--');
   console.error(JSON.stringify({
+    origin: origin,
     message: err.message,
     properties: err,
     stack: err.stack

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -325,16 +325,18 @@ describe('end-to-end', function() {
         });
       });
 
-      it('returns descriptive error for ECONNREFUSED', function(done) {
+      it('returns descriptive result for ECONNREFUSED', function(done) {
         givenDataSource(
           {
             port: 65000 // hopefully nobody is listening there
           },
           function(err, definition) {
             if (err) return done(err);
-            definition.testConnection(function(err) {
-              expect(err, 'err').to.exist;
-              expect(err.code).to.equal('ECONNREFUSED');
+            definition.testConnection(function(err, status, pingError) {
+              if (err) return done(err);
+              expect(status, 'status').to.be.false;
+              expect(pingError, 'pingError').to.exist;
+              expect(pingError.code).to.equal('ECONNREFUSED');
               done();
             });
           });
@@ -347,9 +349,11 @@ describe('end-to-end', function() {
           },
           function(err, definition) {
             if (err) return done(err);
-            definition.testConnection(function(err) {
-              expect(err, 'err').to.exist;
-              expect(err.code).to.equal('ER_ACCESS_DENIED_ERROR');
+            definition.testConnection(function(err, status, pingError) {
+              if (err) return done(err);
+              expect(status, 'status').to.be.false;
+              expect(pingError, 'pingError').to.exist;
+              expect(pingError.code).to.equal('ER_ACCESS_DENIED_ERROR');
               done();
             });
           });


### PR DESCRIPTION
- test: isolate `testConnection` tests
- testConnection: fix a typo in error message
- datasource-invoke: handle sync errors
- report `ping` errors as HTTP 200

/to @ritch please review
