### PR TITLE
Ensure ACLs are ordered and have unique IDs

### DIFF
--- a/models.json
+++ b/models.json
@@ -166,7 +166,7 @@
           "foreignKey": "modelId"
         },
         "accessControls": {
-          "embed": {"name": "acls", "as": "array"},
+          "embed": {"name": "acls", "as": "array", "includeIndex": true},
           "type": "hasMany",
           "model": "ModelAccessControl",
           "foreignKey": "modelId"
@@ -232,11 +232,12 @@
       "id": {"type": "string", "id": true, "json": false},
       "modelId": {"type": "string", "required": true, "json": false},
       "facetName": {"type": "string", "required": true, "json": false},
+      "accessType": {"type": "string"},
       "principalType": {"type": "string"},
       "principalId": {"type": "string"},
       "permission": {"type": "string", "required": true},
       "property": {"type": "string"},
-      "route": {"type": "string"}
+      "index": {"type": "number", "json": false, "default": 0}
     },
     "public": true,
     "dataSource": "db",

--- a/models/definition.js
+++ b/models/definition.js
@@ -115,9 +115,12 @@ Definition.addRelatedToCache = function(cache, fileData, facetName, fk) {
     var properties = Entity.definition.properties;
 
     if(Array.isArray(relatedData)) {
-      relatedData.forEach(function(config) {
+      relatedData.forEach(function(config, index) {
         config[relation.foreignKey] = fk;
         config.facetName = facetName;
+        if(relation.embed && relation.embed.includeIndex) {
+          config.index = index;
+        }
         debug('addRelatedToCache %s %j', relation.model, config);
         Entity.addToCache(cache, config);
       });

--- a/models/facet.js
+++ b/models/facet.js
@@ -120,6 +120,7 @@ Facet.loadIntoCache = function(cache, facetName, allConfigFiles, cb) {
         debug('loading [%s] model definition into cache', def.name);
 
         var uniqueId = ModelDefinition.getUniqueId(def);
+
         ModelDefinition.addToCache(cache, def);
         ModelDefinition.addRelatedToCache(cache, def, facetName, uniqueId);
       });

--- a/models/model-access-control.js
+++ b/models/model-access-control.js
@@ -1,6 +1,7 @@
 var app = require('../app');
 var ACL = require('loopback').ACL;
 var Role = require('loopback').Role;
+var WorkspaceEntity = app.models.WorkspaceEntity;
 
 /**
  * Represents an Access Control configuration.
@@ -106,3 +107,27 @@ ModelAccessControl.getBuiltinRoles = function(cb) {
     { name: 'The user owning the object', value: Role.OWNER },
   ]);
 };
+
+var baseCreate = ModelAccessControl.create;
+ModelAccessControl.create = function(data, cb) {
+  var self = this;
+  this.findOne({
+    where: { modelId: this.modelId },
+    order: 'index DESC'
+  }, function(err, accessControl) {
+    if(err) return cb(err);
+    var index = 0;
+
+    if(accessControl) {
+      index = accessControl.index + 1;
+    }
+
+    data.index = index;
+    baseCreate.call(self, data, cb);
+  });
+}
+
+ModelAccessControl.getUniqueId = function(data) {
+  var sep = this.settings.idSeparator || '.';
+  return data.modelId + sep + data.index;
+}

--- a/models/model-definition.js
+++ b/models/model-definition.js
@@ -35,6 +35,17 @@ ModelDefinition.getConfigFromCache = function(cache, modelDef) {
   var relations = this.getEmbededRelations();
   relations.forEach(function(relation) {
     var relatedData = getRelated(cache, modelDef.id, relation);
+    if(relation.model === 'ModelAccessControl') {
+      relatedData = relatedData.sort(function(a, b) {
+        if (a.index < b.index) {
+          return -1;
+        }
+        if (a.index > b.index) {
+          return 1;
+        }
+        return 0;
+      });
+    }
     configData[relation.as] = formatRelatedData(relation, relatedData);
   });
 

--- a/models/workspace-entity.js
+++ b/models/workspace-entity.js
@@ -118,6 +118,10 @@ WorkspaceEntity.getConfigFile = function(facetName, obj) {
   return new ConfigFile({path: this.getPath(facetName, obj)});
 }
 
+WorkspaceEntity.prototype.getConfigFile = function() {
+  return this.constructor.getConfigFile(this.facetName, this);
+}
+
 WorkspaceEntity.getConfigFromData = function(data) {
   var properties = this.definition.properties;
   var result = {};

--- a/test/model-access-control.js
+++ b/test/model-access-control.js
@@ -1,8 +1,67 @@
 var app = require('../app');
+var ModelDefinition = app.models.ModelDefinition;
 var ModelAccessControl = app.models.ModelAccessControl;
 var TestDataBuilder = require('loopback-testing').TestDataBuilder;
 
 describe('ModelAccessControl', function() {
+  describe('ModelAccessControl.create()', function() {
+    beforeEach(givenBasicWorkspace);
+
+    it('should create an accessControl list item', function(done) {
+      ModelDefinition.create({
+        name: 'TestModel',
+        facetName: 'common'
+      }, function(err, model) {
+        model.accessControls.create({
+          principalType: '$role',
+          principalId: '$everyone',
+          permission: 'ALLOW',
+          accessType: '*',
+        }, function() {
+          var configFile = model.getConfigFile();
+          configFile.load(function() {
+            expect(configFile.data.acls).to.eql([{
+              accessType: '*',
+              principalType: '$role',
+              principalId: '$everyone',
+              permission: 'ALLOW' 
+            }]);
+            model.accessControls.create({
+              principalType: '$role',
+              principalId: '$custom',
+              permission: 'DENY',
+              accessType: '*',
+            }, function(err) {
+              if(err) return done(err);
+              configFile.load(function(err) {
+                if(err) return done(err);
+                expect(configFile.data.acls).to.exist;
+                expect(configFile.data.acls).to.have.length(2);
+                expectCorrectOrder(configFile.data.acls);
+                // load from disk
+                model.accessControls(function(err, acl) {
+                  if(err) return done(err);
+                  expectCorrectOrder(acl);
+                  acl.forEach(function(item, index) {
+                    expect(item.index).to.equal(index);
+                  });
+                  done();
+                });
+              });
+
+              function expectCorrectOrder(acl) {
+                var principalIds = acl.map(function(item) {
+                  return item.principalId;
+                });
+                expect(principalIds).to.eql(['$everyone', '$custom']);
+              }
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe('ModelAccessControl.getAccessTypes(callback)', function() {
     it('Get the available access types.', function() {
 


### PR DESCRIPTION
- fixes an issue where ACLs are being removed unintentionally
- ensures the order of ACLs are the same as defined in the file
- ACL id's now include the index determined from the file or during creation

/to @bajtos @raymondfeng 
