### PR TITLE
Rename `ModelConfig.dataSource` to `dataSourceRef`

### DIFF
--- a/models.json
+++ b/models.json
@@ -104,7 +104,7 @@
           "model": "Facet",
           "foreignKey": "facetName"
         },
-        "dataSource": {
+        "dataSourceRef": {
           "type": "belongsTo",
           "model": "DataSourceDefinition",
           "foreignKey": "dataSource"


### PR DESCRIPTION
Rename the relation property name to preven clash with the foreign-key property, which has the name `dataSource` too.

A better solution would be to rename the foreign key from `dataSource` to `dataSourceName`, but that would be a breaking change for both Studio a generator-loopback.

Close #125

/to @ritch please review