### PR TITLE
Use discoverSchema for the case where options.schema is not present

### DIFF
--- a/models/data-source-definition.js
+++ b/models/data-source-definition.js
@@ -139,9 +139,9 @@ DataSourceDefinition.prototype.discoverModelDefinition = function(name, options,
   if(!options) options = {};
 
   this._setDefaultSchema(options);
-  this.invokeMethodInWorkspace('discoverSchemas', name, options, function(err, result) {
+  this.invokeMethodInWorkspace('discoverSchema', name, options, function(err, result) {
     if(err) return cb(err);
-    cb(null, result[options.schema + '.' + name]);
+    cb(null, result);
   });
 }
 


### PR DESCRIPTION
/to @ritch 

When options.schema is not passed, the discovery defaults to a given schema. The key of the returned definitions will be schema.table. Using options.schema +'.'+ table will not work.
