### PR TITLE
Workspace: do not forward HOST and PORT to child

### DIFF
--- a/models/workspace.js
+++ b/models/workspace.js
@@ -290,12 +290,21 @@ Workspace.start = function(cb) {
 
     try {
       debug('starting a child process in %s', process.env.WORKSPACE_DIR);
+
+      // Forward env variables like PATH, but remove HOST and PORT
+      // to prevent the target app from listening on the same host:port
+      // as the workspace is listening
+      var env = extend({}, process.env);
+      delete env.PORT;
+      delete env.HOST;
+
       Workspace._child = spawn(
         process.execPath,
         ['.'],
         {
           cwd: process.env.WORKSPACE_DIR,
-          stdio: 'inherit'
+          stdio: 'inherit',
+          env: env
         });
     } catch(err) {
       debug('spawn failed %s', err);

--- a/test/helpers/given.js
+++ b/test/helpers/given.js
@@ -8,19 +8,24 @@ var given = module.exports;
  * @param {function(Error=)} done callback
  */
 given.uniqueServerPort = function(done) {
-  var FacetSetting = models.FacetSetting;
 
   // Use PID to generate a port number in the range 10k-50k
   // that is unique for each test process
   var port = 10000 + (process.pid % 40000);
 
-  var props =  { facetName: 'server', name: 'port' };
+  given.facetSetting('server', 'port', port, done);
+};
+
+given.facetSetting = function(facetName, settingName, settingValue, done) {
+  var FacetSetting = models.FacetSetting;
+
+  var props =  { facetName: facetName, name: settingName };
   FacetSetting.findOne({ where: props }, function(err, entry) {
     if (err) return done(err);
     if (!entry)
       entry = new FacetSetting(props);
 
-    entry.value = port;
+    entry.value = settingValue;
     entry.save(done);
   });
 };


### PR DESCRIPTION
Modify `Workspace.start` to remove `HOST` and `PORT` variables from
the environment passed to the spawned child process.

This fixes a problem in Studio, where `PORT=4000 strong-studio`
could not start the child process, because the child could not listen
on the port 4000, as that port was already in used by Studio itself.

/to @ritch please review
/cc @seanbrookes I have discovered this problem while troubleshooting https://github.com/strongloop/strong-studio/issues/390. I am cc-ing you so that you are aware of this issue.
