### PR TITLE
Update available-connectors.json with the support of SAP HANA

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -244,5 +244,37 @@
       "version": "^0.2"
     },
     "supportedByStrongLoop": false
-  }
+  },
+  {
+    "name": "saphana",
+    "description": "SAP HANA",
+    "baseModel": "PersistedModel",
+    "features": {
+      "discovery": true,
+      "migration": true
+    },
+    "settings": {
+      "host": {
+        "type": "string"
+      },
+      "port": {
+        "type": "number"
+      },
+      "user": {
+        "type": "string"
+      },
+      "password": {
+        "type": "string",
+        "display": "password"
+      },
+      "database": {
+        "type": "string"
+      }
+    },
+    "package": {
+      "name": "loopback-connector-saphana",
+      "version": "^0.7"
+    },
+    "supportedByStrongLoop": false
+  }  
 ]


### PR DESCRIPTION
To support SAP HANA database, the in-memory column store made by SAP SE.
All tests have been passed successfully (with a connection to SAP HANA server).
And the module loopback-connector-saphana has been published in npmjs.org.
