### PR TITLE
api-server: add jshint to devDependencies

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -20,6 +20,9 @@ template.package = {
   },
   "optionalDependencies": {
     "loopback-explorer": "^1.1.0"
+  },
+  "devDependencies": {
+    "jshint": "^2.5.6"
   }
 };
 

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -640,7 +640,7 @@ function execNpm(args, options, cb) {
 
 function installSandboxPackages(cb) {
   this.timeout(300 * 1000);
-  install(SANDBOX, PKG_CACHE, cb);
+  install(SANDBOX, PKG_CACHE, ['dependencies', 'devDependencies'], cb);
 }
 
 function listTableNames(connection, cb) {


### PR DESCRIPTION
`package.json` scaffolded by api-server template includes a `pretest` script executing `jshint`, but `jshint` is not included as a dependency.

This causes `npm test` in the scaffolded project to fail on machines where jshint is not installed globally.

This change fixes the problem by adding `jshint` to `devDependencies`.

The test are failing on a machine without a global jshint due to a bug in strong-cached-install - see https://github.com/strongloop/strong-cached-install/pull/4. However, since they are failing without this patch too, IMO we don't have to wait for that other PR to be landed first.

/to @ritch please review
