### PR TITLE
templates/api-server: remove `url` from config

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -40,8 +40,7 @@ template.server = {
   config: [
     { name: 'restApiRoot', value: '/api' },
     { name: 'host', value: '0.0.0.0' }, // Listen on all interfaces
-    { name: 'port', value: 3000 },
-    { name: 'url', value: 'http://localhost:3000/' } // Informational
+    { name: 'port', value: 3000 }
   ],
 
   modelConfigs: [


### PR DESCRIPTION
Modify "api-server" template and remove `url` from the generated
`server/config.json` file. That way loopback generates the URL
using the real HOST and PORT values.

This fixes a problem where environmental overrides were not honoured
in the URL printed at application start

```
$ PORT=4000 node .
Browse your REST API at http://localhost:3000/explorer
Web server listening at: http://localhost:3000/
```

Related: https://github.com/strongloop/loopback/pull/659
Fixes #151 

/to @ritch @raymondfeng please review