### PR TITLE
Include loopback in model sources

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -13,8 +13,8 @@ template.package = {
   "dependencies": {
     "compression": "^1.0.3",
     "errorhandler": "^1.1.1",
-    "loopback": "^2.0.0",
-    "loopback-boot": "^2.0.0",
+    "loopback": "^2.5.0",
+    "loopback-boot": "^2.2.0",
     "loopback-datasource-juggler": "^2.7.0",
     "serve-favicon": "^2.0.1"
   },
@@ -33,7 +33,12 @@ template.common = {
 template.server = {
   facet: {
     modelsMetadata: {
-      sources: ['../common/models', './models']
+      sources: [
+        'loopback/common/models',
+        'loopback/server/models',
+        '../common/models',
+        './models',
+      ]
     }
   },
 

--- a/test/facet.js
+++ b/test/facet.js
@@ -45,7 +45,12 @@ describe('Facet', function () {
       var content = fs.readJsonFileSync(SANDBOX + '/server/model-config.json');
       expect(content).to.have.property('_meta');
       expect(content._meta).to.eql({
-        sources: ['../common/models', './models']
+        sources: [
+          'loopback/common/models',
+          'loopback/server/models',
+          '../common/models',
+          './models'
+        ]
       });
     });
 


### PR DESCRIPTION
As of loopback 2.5, built-in models are defined in a layout compatible
with loopback-boot and loopback-workspace.

Adding loopback to model sources makes it is easier to programatically
detect which built-in models are used by the facet.

Requires https://github.com/strongloop/loopback-boot/pull/60

A follow-up for https://github.com/strongloop/loopback/pull/635, a part of https://github.com/strongloop-internal/scrum-loopback/issues/34.

/to @ritch please review
