### PR TITLE
ModelDefinition: make idInjection true by default

### DIFF
--- a/models.json
+++ b/models.json
@@ -128,7 +128,7 @@
       "base": "string",
       "strict": "boolean",
       "public": "boolean",
-      "idInjection": "boolean",
+      "idInjection": { "type": "boolean", "default": true },
       "scopes": "object",
       "indexes": "object",
       "options": "object"

--- a/test/model-definition.js
+++ b/test/model-definition.js
@@ -10,7 +10,7 @@ var ref = TestDataBuilder.ref;
 var ConfigFile = app.models.ConfigFile;
 
 describe('ModelDefinition', function() {
-  
+
   describe('CRUD', function () {
     beforeEach(givenBasicWorkspace);
 
@@ -46,6 +46,10 @@ describe('ModelDefinition', function() {
           expect(exists).to.equal(true);
           done();
         });
+      });
+
+      it('should set `idInjection` to true by default', function() {
+        expect(this.modelDef.idInjection).to.equal(true);
       });
     });
 


### PR DESCRIPTION
/to @ritch @raymondfeng please review
/cc @dashby3000 you were asking about this in Slack recently. This patch changes the default value to `true`, so that you should not need to change it in most cases.
