### PR TITLE
Remove "npm install loopback-explorer" log

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,9 +61,13 @@ try {
     console.log('Browse your REST API at %s%s', baseUrl, explorer.route);
   });
 } catch(e){
-  console.log(
-    'Run `npm install loopback-explorer` to enable the LoopBack explorer'
-  );
+  // Print the message only when the app was started via `app.listen()`.
+  // Do not print any message when the project is used as a component.
+  app.once('started', function(baseUrl) {
+    console.log(
+      'Run `npm install loopback-explorer` to enable the LoopBack explorer'
+    );
+  });
 }
 
 /*

--- a/templates/components/api-server/template/server/boot/explorer.js
+++ b/templates/components/api-server/template/server/boot/explorer.js
@@ -3,9 +3,13 @@ module.exports = function mountLoopBackExplorer(server) {
   try {
     explorer = require('loopback-explorer');
   } catch(err) {
-    console.log(
-      'Run `npm install loopback-explorer` to enable the LoopBack explorer'
-    );
+    // Print the message only when the app was started via `server.listen()`.
+    // Do not print any message when the project is used as a component.
+    server.once('started', function(baseUrl) {
+      console.log(
+        'Run `npm install loopback-explorer` to enable the LoopBack explorer'
+      );
+    });
     return;
   }
 


### PR DESCRIPTION
loopback-explorer is a devDependency that is not included when
the project is installed as a dependency.

This commit changes both the explorer boot script template and `app.js`
to print the message only when the server was started via `app.listen`.

A part of https://github.com/strongloop/strong-arc/issues/380

The same fix was already applied to Strong Studio - see https://github.com/strongloop/strong-arc/pull/552/files#diff-1

/to @ritch or @raymondfeng please review
