### PR TITLE
template/api-server: introduce middleware.json

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -13,8 +13,8 @@ template.package = {
   "dependencies": {
     "compression": "^1.0.3",
     "errorhandler": "^1.1.1",
-    "loopback": "^2.5.0",
-    "loopback-boot": "^2.2.0",
+    "loopback": "^2.8.0",
+    "loopback-boot": "^2.4.0",
     "loopback-datasource-juggler": "^2.7.0",
     "serve-favicon": "^2.0.1"
   },

--- a/templates/components/api-server/template/server/boot/root.js
+++ b/templates/components/api-server/template/server/boot/root.js
@@ -1,6 +1,0 @@
-module.exports = function(server) {
-  // Install a `/` route that returns server status
-  var router = server.loopback.Router();
-  router.get('/', server.loopback.status());
-  server.use(router);
-};

--- a/templates/components/api-server/template/server/middleware.json
+++ b/templates/components/api-server/template/server/middleware.json
@@ -1,0 +1,27 @@
+{
+  "initial:before": {
+    "loopback#favicon": {}
+  },
+  "initial": {
+    "compression": {}
+  },
+  "session": {
+  },
+  "auth": {
+  },
+  "parse": {
+  },
+  "routes": {
+    "loopback#status": {
+      "paths": "/"
+    }
+  },
+  "files": {
+  },
+  "final": {
+    "loopback#urlNotFound": {}
+  },
+  "final:after": {
+    "errorhandler": {}
+  }
+}

--- a/templates/components/api-server/template/server/server.js
+++ b/templates/components/api-server/template/server/server.js
@@ -3,14 +3,6 @@ var boot = require('loopback-boot');
 
 var app = module.exports = loopback();
 
-// Set up the /favicon.ico
-app.use(loopback.favicon());
-
-// request pre-processing middleware
-app.use(loopback.compress());
-
-// -- Add your pre-processing middleware here --
-
 // boot scripts mount components like REST API
 boot(app, __dirname);
 
@@ -19,15 +11,8 @@ boot(app, __dirname);
 // passing the static middleware are hitting the file system
 // Example:
 //   var path = require('path');
-//   app.use(loopback.static(path.resolve(__dirname, '../client')));
-
-// Requests that get this far won't be handled
-// by any middleware. Convert them into a 404 error
-// that will be handled later down the chain.
-app.use(loopback.urlNotFound());
-
-// The ultimate error handler.
-app.use(loopback.errorHandler());
+//   app.middleware('files', loopback.static(
+//     path.resolve(__dirname, '../client')));
 
 app.start = function() {
   // start the web server

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -113,6 +113,21 @@ describe('end-to-end', function() {
       ], done);
     });
 
+    it('includes all built-in phases in `middleware.json`', function(done) {
+      var builtinPhases = readBuiltinPhasesFromSanbox();
+
+      var middleware = fs.readJsonFileSync(
+        path.resolve(SANDBOX, 'server/middleware.json'));
+      var phaseNames = Object.keys(middleware).filter(isNameOfMainPhase);
+
+      expect(phaseNames).to.eql(builtinPhases);
+      done();
+
+      function isNameOfMainPhase(name) {
+        return !/:(before|after)$/.test(name);
+      }
+    });
+
     it('passes scaffolded tests', function(done) {
       execNpm(['test'], { cwd: SANDBOX }, function(err, stdout, stderr) {
         done(err);
@@ -682,4 +697,11 @@ function configureCustomModel(done) {
     dataSource: 'db',
     facetName: 'server'
   }, done);
+}
+
+function readBuiltinPhasesFromSanbox() {
+  var loopback = require(SANDBOX + '/node_modules/loopback');
+  var app = loopback();
+  app.lazyrouter(); // initialize request handling phases
+  return app._requestHandlingPhases.getPhaseNames();
 }


### PR DESCRIPTION
Rework the scaffolded server app to register middleware via
the new `middleware.json` file.

Note: `serve-static` is kept inside `server/server.js` for now,
as there isn't any mechanism for resolving paths in middleware config
specified in `middleware.json`. I will fix this later.

/to @ritch @raymondfeng please review

A part of #167
