### PR TITLE
Fix status middleware

### DIFF
--- a/templates/components/api-server/template/server/boot/root.js
+++ b/templates/components/api-server/template/server/boot/root.js
@@ -1,0 +1,6 @@
+module.exports = function(server) {
+  // Install a `/` route that returns server status
+  var router = server.loopback.Router();
+  router.get('/', server.loopback.status());
+  server.use(router);
+};

--- a/templates/components/api-server/template/server/middleware.json
+++ b/templates/components/api-server/template/server/middleware.json
@@ -12,9 +12,6 @@
   "parse": {
   },
   "routes": {
-    "loopback#status": {
-      "paths": "/"
-    }
   },
   "files": {
   },

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -61,6 +61,13 @@ describe('end-to-end', function() {
         });
     });
 
+    it('provides status on the root url only', function(done) {
+      // See https://github.com/strongloop/generator-loopback/issues/80
+      request(app)
+        .get('/does-not-exist')
+        .expect(404, done);
+    });
+
     it('has authentication enabled', function(done) {
       request(app)
         .get('/api/users')
@@ -210,7 +217,7 @@ describe('end-to-end', function() {
 
   describe('discovery', function() {
     this.timeout(10000);
-    
+
     var connection;
     before(function(done) {
       connection = setupConnection(done);


### PR DESCRIPTION
Before this change, the scaffolded application had status middleware
configured to handle all requests. As a result, it was handling unknown
URLs too.

This patch partially reverts 3071a26 and brings back the original server/boot/root.js script.

**Current version**

```
//server/middleware.json
{
  "routes": {
    "loopback#status": {
      "paths": "/"
    }
  }
}
```

**Upcoming version**
```
//server/boot/root.js
module.exports = function(server) {
  // Install a `/` route that returns server status
  var router = server.loopback.Router();
  router.get('/', server.loopback.status());
  server.use(router);
};
```

---

A part of strongloop/generator-loopback#80

/to @ritch or @raymondfeng please review