### PR TITLE
Fix package.json handling

### DIFF
--- a/connector.js
+++ b/connector.js
@@ -184,6 +184,12 @@ connector._loadFromFile = function(cb) {
     ConfigFile.findPackageDefinitions(function(err, files) {
       if (err) return done(err);
       async.each(files, function(f, next) {
+        var dir = f.getDirName();
+        if (dir !== '.') {
+          debug('Skipping package.json in %j', dir);
+          return next();
+        }
+
         // TODO(bajtos) Generalize and move this code to WorkspaceEntity
         f.load(function(err) {
           if (err) return next(err);

--- a/models/facet.js
+++ b/models/facet.js
@@ -7,7 +7,6 @@ var ModelDefinition = app.models.ModelDefinition;
 var DataSourceDefinition = app.models.DataSourceDefinition;
 var ModelConfig = app.models.ModelConfig;
 var ConfigFile = app.models.ConfigFile;
-var PackageDefinition = app.models.PackageDefinition;
 var FacetSetting = app.models.FacetSetting;
 
 /**
@@ -42,7 +41,6 @@ Facet.loadIntoCache = function(cache, facetName, allConfigFiles, cb) {
   var modelConfigs = ConfigFile.getFileByBase(configFiles, 'model-config');
   var dataSources = ConfigFile.getFileByBase(configFiles, 'datasources');
   var modelDefinitionFiles = ConfigFile.getModelDefFiles(configFiles, facetName);
-  var packageFile = ConfigFile.getFileByBase(configFiles, 'package');
   var steps = [];
 
   var facetData = {
@@ -50,16 +48,6 @@ Facet.loadIntoCache = function(cache, facetName, allConfigFiles, cb) {
   };
   debug('adding to cache facet [%s]');
   var facetId = Facet.addToCache(cache, facetData);
-
-  if(packageFile) {
-    steps.push(function(cb) {
-      packageFile.load(cb);
-    }, function(cb) {
-      packageFile.data.facetName = facetName;
-      PackageDefinition.addToCache(cache, packageFile.data || {});
-      cb();
-    });
-  }
 
   if(facetConfig) {
     steps.push(function(cb) {
@@ -195,17 +183,6 @@ Facet.saveToFs = function(cache, facetData, cb) {
 
     addFileToSave(facetConfigFile);
   }
-
-  PackageDefinition.allFromCache(cache).forEach(function(package) {
-    if(package.facetName === facetName) {
-      var packageFile = new ConfigFile({
-        path: PackageDefinition.getPath(facetName, package),
-        data: package
-      });
-      delete package.facetName;
-      addFileToSave(packageFile);
-    }
-  });
 
   if (hasApp) {
     var dataSoureConfig = {};


### PR DESCRIPTION
 - Remove PackageDefinition-related code from Facet, since PackageDefinition is always top-level, it is never associated with a Facet. The patch removes the dead code forgotten in the refactoring that introduced the concept of facets.
 - Modify the code loading package.json to ignore files in subdirectories, because we don't support workspaces with multiple projects.

See #181

/to @ritch please review