### PR TITLE
Add .strong-pm to .gitignore

### DIFF
--- a/templates/components/api-server/template/.gitignore
+++ b/templates/components/api-server/template/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .project
+.strong-pm
 *.sublime-*
 .DS_Store
 *.seed


### PR DESCRIPTION
Fix https://groups.google.com/d/topic/loopbackjs/T-W900RZ86I/discussion

I believe this to be the right place to make this change, though I'm not sure if the bug with .gitignore not being copied when a loopback app is scaffolded has been fixed yet.

