### PR TITLE
Fix unit-tests

### DIFF
--- a/test/facet.js
+++ b/test/facet.js
@@ -10,12 +10,12 @@ describe('Facet', function () {
         name: 'foo'
       }, function(err, def) {
         expect(err).to.not.exist;
-        expect(def).to.not.have.property('id');
+        expect(def).to.not.have.ownProperty('id');
         expect(def.name).to.equal('foo');
         done();
       });
     });
-    
+
     it('omits `name` in config.json', function() {
       var content = fs.readJsonFileSync(SANDBOX + '/server/config.json');
       expect(content).to.not.have.property('name');


### PR DESCRIPTION
Fix the check "Facet does not have id property" to check for
own properties only.