### PR TITLE
disable legacy explorer routes by default

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -13,9 +13,9 @@ template.package = {
   "dependencies": {
     "compression": "^1.0.3",
     "errorhandler": "^1.1.1",
-    "loopback": "^2.8.0",
+    "loopback": "^2.14.0",
     "loopback-boot": "^2.6.5",
-    "loopback-datasource-juggler": "^2.7.0",
+    "loopback-datasource-juggler": "^2.19.0",
     "serve-favicon": "^2.0.1"
   },
   "optionalDependencies": {
@@ -74,7 +74,8 @@ template.server = {
         errorHandler: {
           disableStackTrace: false
         }
-    }}
+    }},
+    { name: 'legacyExplorer', value: false }
   ],
 
   modelConfigs: [

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -153,6 +153,24 @@ describe('end-to-end', function() {
       });
       // the test will time out if `booted` is not emitted
     });
+
+    it('has legacy explorer disabled in config', function (done) {
+      expect(app.get('legacyExplorer'), 'legacyExplorer option').to.be.false();
+      done();
+    });
+
+    it('has legacy explorer route /models disabled', function (done) {
+      request(app)
+        .get('/api/models')
+        .expect(404, done);
+    });
+
+    it('has legacy explorer route /routes disabled', function (done) {
+      request(app)
+        .get('/api/routes')
+        .expect(404, done);
+    });
+
   });
 
   describe('autoupdate', function() {


### PR DESCRIPTION
A companion PR as part of the fix to strongloop/loopback#1134.

[Three tests](https://github.com/greaterweb/loopback-workspace/blob/8b9b7bae0384e9e65cc408b5a4a508ca9183e838/test/end-to-end.js#L157-L172) added. One will confirm the presence of the new `legacyExplorer` option, the other two will check that the routes `/models` and `/routes` are indeed disabled.

The two route tests currently fail with the current LB release. If you wish to test locally against the loopback PR branch fixing issue 1134, please update `/templates/components/api-server/component.js` as follows:

Go to [line 16](https://github.com/greaterweb/loopback-workspace/blob/8b9b7bae0384e9e65cc408b5a4a508ca9183e838/templates/components/api-server/component.js#L16) with a value of:
```json
    "loopback": "^2.8.0",
```

And replace with:
```json
    "loopback": "git://github.com/greaterweb/loopback.git#fix/issue-1134",
```
