### PR TITLE
Remove deprecation warnings

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,8 @@ var boot = require('loopback-boot');
 var started = new Date();
 var env = app.get('env');
 
+app.set('legacyExplorer', false);
+
 // required to support base models
 app.dataSource('db', {
   connector: loopback.Memory,

--- a/models/model-definition.js
+++ b/models/model-definition.js
@@ -22,7 +22,7 @@ var ModelDefinition = app.models.ModelDefinition;
 
 /**
  * - `name` is required and must be unique per `Facet`
- * 
+ *
  * @header Property Validation
  */
 
@@ -140,8 +140,10 @@ function cleanRelatedData(relatedData, relation) {
   }
 }
 
-ModelDefinition.afterCreate = function(next) {
-  var def = this;
+ModelDefinition.observe("after save", function(ctx, next) {
+  if (!ctx.isNewInstance) return next();
+
+  var def = ctx.instance;
   var scriptPath = def.getScriptPath();
 
   fs.exists(scriptPath, function(exists) {
@@ -151,7 +153,7 @@ ModelDefinition.afterCreate = function(next) {
       createScript(def, scriptPath, next);
     }
   });
-}
+});
 
 ModelDefinition.prototype.getClassName = function() {
   if(!this.name) return null;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lodash": "~2.4.1",
     "loopback": "^2.0.0",
     "loopback-boot": "^1.0.0",
-    "loopback-datasource-juggler": "^2.6.1",
+    "loopback-datasource-juggler": "^2.22.0",
     "method-override": "^2.1.1",
     "morgan": "^1.2.0",
     "ncp": "^2.0.0",

--- a/test/model-definition.js
+++ b/test/model-definition.js
@@ -162,6 +162,7 @@ describe('ModelDefinition', function() {
     it('includes `name` property', function(done) {
       new TestDataBuilder()
         .define('model', ModelDefinition, {
+          facetName: 'server',
           name: 'test-model'
         })
         .buildTo(this, function(err) {
@@ -198,6 +199,7 @@ describe('ModelDefinition', function() {
     it('includes all custom properties', function(done) {
       new TestDataBuilder()
         .define('model', ModelDefinition, {
+          facetName: 'server',
           name: 'test-model',
           custom: 'custom'
         })


### PR DESCRIPTION
Replace `beforeValidate` with "before save" and `afterCreate` with "after save" hooks.

Disable the legacy explorer routes in the app exported by workspace.

Requires https://github.com/strongloop/loopback-datasource-juggler/pull/515

/to @raymondfeng @ritch please review. I'd like to get this landed by EOW, at most on Monday, because I am running a workshop on Tuesday next week and the deprecation warnings printed by `slc loopback` are rather ugly.