### PR TITLE
Dependency cleanup

### DIFF
--- a/models/model-definition.js
+++ b/models/model-definition.js
@@ -177,7 +177,7 @@ var MODEL_SCRIPT_TEMPLATE = fs.readFileSync(templatePath, 'utf8');
 function createScript(def, out, cb) {
   var script;
   try {
-    script = _.template(MODEL_SCRIPT_TEMPLATE, {
+    script = _.template(MODEL_SCRIPT_TEMPLATE)({
       modelDef: def,
       modelClassName: def.getClassName()
     });

--- a/models/model-definition.js
+++ b/models/model-definition.js
@@ -4,10 +4,6 @@ var assert = require('assert');
 var extend = require('util')._extend;
 var app = require('../app');
 var async = require('async');
-var underscoreString = require('underscore.string');
-var dasherize = underscoreString.dasherize;
-var camelize = underscoreString.camelize;
-var classify = underscoreString.classify;
 var ConfigFile = app.models.ConfigFile;
 var _ = require('lodash');
 
@@ -94,7 +90,7 @@ ModelDefinition.getPath = function(facetName, obj) {
 ModelDefinition.toFilename = function(name) {
   if(name === name.toUpperCase()) return name.toLowerCase();
   if(~name.indexOf('-')) return name.toLowerCase();
-  var dashed = dasherize(name);
+  var dashed = _.kebabCase(name);
   var split = dashed.split('');
   if(split[0] === '-') split.shift();
 
@@ -157,7 +153,7 @@ ModelDefinition.observe("after save", function(ctx, next) {
 
 ModelDefinition.prototype.getClassName = function() {
   if(!this.name) return null;
-  return classify(dasherize(this.name));
+  return _.capitalize(_.camelCase(this.name));
 }
 
 ModelDefinition.prototype.getScriptPath = function() {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "ncp": "^2.0.0",
     "serve-favicon": "^2.0.1",
     "strong-wait-till-listening": "^1.0.0",
-    "temp": "~0.8.0",
-    "underscore.string": "~2.3.3"
+    "temp": "~0.8.0"
   },
   "optionalDependencies": {
     "loopback-explorer": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "morgan": "^1.2.0",
     "ncp": "^2.0.0",
     "serve-favicon": "^2.0.1",
-    "strong-wait-till-listening": "^1.0.0",
-    "temp": "~0.8.0"
+    "strong-wait-till-listening": "^1.0.0"
   },
   "optionalDependencies": {
     "loopback-explorer": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "errorhandler": "^1.1.1",
     "fs-extra": "~0.11.0",
     "glob": "~4.0.2",
-    "lodash": "~2.4.1",
+    "lodash": "^3.0.0",
     "loopback": "^2.0.0",
     "loopback-boot": "^1.0.0",
     "loopback-datasource-juggler": "^2.22.0",


### PR DESCRIPTION
* Upgrade lodash to 3.x
 * update `_.template` usage
 * convert underscore.string usage to equivalent lodash functions
* Remove underscore.string
* Remove unused `temp` dependency