### PR TITLE
api-server: configure default mixin sources

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -44,6 +44,12 @@ template.server = {
         'loopback/server/models',
         '../common/models',
         './models',
+      ],
+      mixins: [
+        'loopback/common/mixins',
+        'loopback/server/mixins',
+        '../common/mixins',
+        './mixins',
       ]
     }
   },

--- a/test/facet.js
+++ b/test/facet.js
@@ -50,6 +50,12 @@ describe('Facet', function () {
           'loopback/server/models',
           '../common/models',
           './models'
+        ],
+        mixins: [
+          'loopback/common/mixins',
+          'loopback/server/mixins',
+          '../common/mixins',
+          './mixins'
         ]
       });
     });


### PR DESCRIPTION
As a follow-up for https://github.com/strongloop/loopback-boot/pull/131, this patch modifies the scaffolded `model-config.json` to include lookup paths for mixins.

 - loopback/common/mixins
 - loopback/server/mixins
 - ../common/mixins
 - ./mixins

Connect to strongloop/loopback-boot#79

/to @ritch please review
/cc @PradnyaBaviskar