### PR TITLE
api-server template: add strong-express-metrics

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -17,6 +17,7 @@ template.package = {
     "loopback": "^2.14.0",
     "loopback-boot": "^2.6.5",
     "loopback-datasource-juggler": "^2.19.0",
+    "strong-express-metrics": "^1.1.0",
     "serve-favicon": "^2.0.1"
   },
   "optionalDependencies": {

--- a/templates/components/api-server/template/server/middleware.json
+++ b/templates/components/api-server/template/server/middleware.json
@@ -1,6 +1,7 @@
 {
   "initial:before": {
-    "loopback#favicon": {}
+    "loopback#favicon": {},
+    "strong-express-metrics": {}
   },
   "initial": {
     "compression": {},

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -195,6 +195,19 @@ describe('end-to-end', function() {
         .expect(422)
         .end(done);
     });
+
+    it('reports API usage metrics', function(done) {
+      var recordedUrls = [];
+      require(SANDBOX + '/node_modules/strong-express-metrics')
+        .onRecord(function(data) { recordedUrls.push(data.request.url); });
+      request(app).get('/')
+        .expect(200)
+        .end(function(err, res) {
+          if (err) return done(err);
+          expect(recordedUrls).to.eql(['/']);
+          done();
+        });
+    });
   });
 
   describe('autoupdate', function() {


### PR DESCRIPTION
Modify the template to configure strong-express-metrics for all scaffolded applications (projects).

Close strongloop-internal/scrum-loopback#176

/to @raymondfeng @ritch please review