### PR TITLE
Revert "api-server template: add strong-express-metrics"

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -17,7 +17,6 @@ template.package = {
     "loopback": "^2.14.0",
     "loopback-boot": "^2.6.5",
     "loopback-datasource-juggler": "^2.19.0",
-    "strong-express-metrics": "^1.1.0",
     "serve-favicon": "^2.0.1"
   },
   "optionalDependencies": {

--- a/templates/components/api-server/template/server/middleware.json
+++ b/templates/components/api-server/template/server/middleware.json
@@ -1,7 +1,6 @@
 {
   "initial:before": {
-    "loopback#favicon": {},
-    "strong-express-metrics": {}
+    "loopback#favicon": {}
   },
   "initial": {
     "compression": {},

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -195,19 +195,6 @@ describe('end-to-end', function() {
         .expect(422)
         .end(done);
     });
-
-    it('reports API usage metrics', function(done) {
-      var recordedUrls = [];
-      require(SANDBOX + '/node_modules/strong-express-metrics')
-        .onRecord(function(data) { recordedUrls.push(data.request.url); });
-      request(app).get('/')
-        .expect(200)
-        .end(function(err, res) {
-          if (err) return done(err);
-          expect(recordedUrls).to.eql(['/']);
-          done();
-        });
-    });
   });
 
   describe('autoupdate', function() {


### PR DESCRIPTION
This reverts commit 6dc86830f5690bc247fbd6f3cbe9215479a29c80.

The module strong-express-metrics has changed the license to StrongLoop only, therefore it's better to not include it in the scaffolded applications by default.

/cc @raymondfeng @altsang @ritch 

I am going to land this without review as it's just `git revert {sha}`.

I am not sure whether we have to release this as a major version, I would prefer to make this a minor release instead. Thoughts?