### PR TITLE
Suppress error stack traces in production

### DIFF
--- a/templates/components/api-server/component.js
+++ b/templates/components/api-server/component.js
@@ -13,10 +13,9 @@ template.package = {
   "dependencies": {
     "compression": "^1.0.3",
     "cors": "^2.5.2",
-    "errorhandler": "^1.1.1",
-    "loopback": "^2.14.0",
+    "loopback": "^2.22.0",
     "loopback-boot": "^2.6.5",
-    "loopback-datasource-juggler": "^2.19.0",
+    "loopback-datasource-juggler": "^2.39.0",
     "serve-favicon": "^2.0.1"
   },
   "optionalDependencies": {

--- a/templates/components/api-server/template/server/middleware.json
+++ b/templates/components/api-server/template/server/middleware.json
@@ -26,6 +26,6 @@
     "loopback#urlNotFound": {}
   },
   "final:after": {
-    "errorhandler": {}
+    "loopback#errorHandler": {}
   }
 }

--- a/templates/components/api-server/template/server/middleware.production.json
+++ b/templates/components/api-server/template/server/middleware.production.json
@@ -1,0 +1,9 @@
+{
+  "final:after": {
+    "loopback#errorHandler": {
+      "params": {
+        "includeStack": false
+      }
+    }
+  }
+}


### PR DESCRIPTION
When running in production, supress error stack traces from the error responses (pages). This change affects the global error handler used, it does not affect strong-remoting's REST handler.

See https://github.com/strongloop/loopback/pull/1502

/to @ritch please review
/cc @raymondfeng 

It seems to me that adding an automated test is too much work & future maintenance, therefore I tested the change only manually.