### PR TITLE
Fix remoting metadata of Workspace.start()

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -395,7 +395,11 @@ module.exports = function(Workspace) {
 
     loopback.remoteMethod(Workspace.start, {
       http: {verb: 'post', path: '/start'},
-      returns: {arg: 'data', type: 'StartResult', root: true}
+      returns: {
+        arg: 'data',
+        type: { pid: Number, host: String, port: Number },
+        root: true
+      }
     });
 
     process.once('exit', function killWorkspaceChild() {


### PR DESCRIPTION
Replace name of an undefined class with an anonymous object definition.

This fixes the following explorer warning:

    Swagger: skipping unknown type "StartResult".

/to @ritch please review
/cc @seanbrookes @rmg 