### PR TITLE
ComponentConfig representing component-config.json

### DIFF
--- a/common/models/component-config.js
+++ b/common/models/component-config.js
@@ -1,0 +1,34 @@
+'use strict';
+module.exports = function(ComponentConfig) {
+  ComponentConfig.validatesPresenceOf('facetName');
+
+  ComponentConfig.validatesPresenceOf('name');
+  ComponentConfig.validatesUniquenessOf('name', { scopedTo: ['app'] });
+
+  ComponentConfig.deserialize = function(cache, facetName, configFile) {
+    var data = configFile.data;
+    Object.keys(data).forEach(function(name) {
+      var value = {
+        configFile: configFile.path,
+        facetName: facetName,
+        name: name,
+        value: data[name],
+      };
+      ComponentConfig.addToCache(cache, value);
+    });
+  };
+
+  ComponentConfig.serialize = function(cache, facetName) {
+    var data = {};
+
+    ComponentConfig.allFromCache(cache).forEach(function(item) {
+      if (item.facetName !== facetName) return;
+      data[item.name] = item.value;
+    });
+
+    if (!Object.keys(data).length) return null; // nothing to save
+    var configFile = ComponentConfig.getConfigFile(facetName);
+    configFile.data = data;
+    return configFile;
+  };
+};

--- a/common/models/component-config.json
+++ b/common/models/component-config.json
@@ -1,0 +1,35 @@
+{
+  "name": "ComponentConfig",
+  "base": "Definition",
+  "defaultConfigFile": "component-config.json",
+  "configFiles": [
+    "component-config.json",
+    "component-config.*.json"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "id": true,
+      "json": false
+    },
+    "facetName": {
+      "type": "string",
+      "required": true,
+      "json": false
+    },
+    "name": {
+      "type": "string",
+      "json": false
+    },
+    "value": {
+      "type": "any"
+    }
+  },
+  "relations": {
+    "facet": {
+      "type": "belongsTo",
+      "model": "Facet",
+      "foreignKey": "facetName"
+    }
+  }
+}

--- a/common/models/facet.js
+++ b/common/models/facet.js
@@ -14,6 +14,7 @@ function ready(Facet) {
 
   var ModelDefinition = app.models.ModelDefinition;
   var Middleware = app.models.Middleware;
+  var ComponentConfig = app.models.ComponentConfig;
   var ModelConfig = app.models.ModelConfig;
 
   /**
@@ -61,6 +62,7 @@ function ready(Facet) {
     var modelConfigs = ConfigFile.getFileByBase(configFiles, 'model-config');
     var dataSources = ConfigFile.getFileByBase(configFiles, 'datasources');
     var middlewares = ConfigFile.getFileByBase(configFiles, 'middleware');
+    var componentConfigs = ConfigFile.getFileByBase(configFiles, 'component-config');
     var modelDefinitionFiles = ConfigFile.getModelDefFiles(configFiles, facetName);
 
     var artifacts = {};
@@ -175,6 +177,16 @@ function ready(Facet) {
       });
     }
 
+    if (componentConfigs) {
+      steps.push(function(cb) {
+        componentConfigs.load(cb);
+      }, function(cb) {
+        debug('adding to cache component-config file [%s]', componentConfigs.path);
+        ComponentConfig.deserialize(cache, facetName, componentConfigs);
+        cb();
+      });
+    }
+
     function createLoader(a) {
       return function(cb) {
         Facet.artifactTypes[a].load(cache, facetName, artifacts[a], cb);
@@ -256,6 +268,11 @@ function ready(Facet) {
       var middlewareFile = Middleware.serialize(cache, facetName);
       if (middlewareFile) {
         addFileToSave(middlewareFile);
+      }
+
+      var componentConfigFile = ComponentConfig.serialize(cache, facetName);
+      if (componentConfigFile) {
+        addFileToSave(componentConfigFile);
       }
 
       var cachedModelConfigs = ModelConfig.allFromCache(cache);

--- a/common/models/workspace-entity.js
+++ b/common/models/workspace-entity.js
@@ -107,7 +107,7 @@ module.exports = function(WorkspaceEntity) {
   }
 
   WorkspaceEntity.getPath = function(facetName, obj) {
-    if(obj.configFile) return obj.configFile;
+    if(obj && obj.configFile) return obj.configFile;
     return path.join(facetName, this.settings.defaultConfigFile);
   }
 

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -72,6 +72,10 @@
     "public": true,
     "dataSource": "db"
   },
+  "ComponentConfig": {
+    "public": true,
+    "dataSource": "db"
+  },
   "DataSourceDefinition": {
     "public": true,
     "dataSource": "db"

--- a/test/component-config.test.js
+++ b/test/component-config.test.js
@@ -1,0 +1,39 @@
+'use strict';
+var app = require('../');
+var path = require('path');
+var fs = require('fs-extra');
+var expect = require('chai').expect;
+
+var ComponentConfig = app.models.ComponentConfig;
+
+describe('ComponentConfig', function() {
+  beforeEach(givenBasicWorkspace);
+  beforeEach(findComponentConfigs);
+
+  it('should read data from "component-config.json"', function() {
+    expect(this.componentConfigs).to.have.length(1);
+    var explorer = this.componentConfigs[0];
+    expect(explorer.configFile).to.equal('server/component-config.json');
+    // see templates/components/api-server/template/server/component-config
+    expect(explorer.name).to.equal('loopback-component-explorer');
+    expect(explorer.value).to.eql({ mountPath: '/explorer' });
+  });
+
+  it('should write data to "component-config.json"', function() {
+    var component = new ComponentConfig({
+      facetName: 'server',
+      name: 'loopback-component-foobar',
+      value: {
+        configKey: 'configValue'
+      }
+    });
+    return component.save().then(function() {
+      var cfgFile = path.resolve(SANDBOX, 'server', 'component-config.json');
+      var data = fs.readJsonSync(cfgFile);
+      expect(data).to.have.property('loopback-component-foobar');
+      expect(data['loopback-component-foobar']).to.eql({
+        configKey: 'configValue'
+      });
+    });
+  });
+});

--- a/test/support.js
+++ b/test/support.js
@@ -113,6 +113,7 @@ findFacets = findOfType('facets', models.Facet);
 findFacetSettings = findOfType('facetSettings', models.FacetSetting);
 findDataSourceDefinitions = findOfType('dataSources', models.DataSourceDefinition);
 findMiddlewares = findOfType('middlewares', models.Middleware);
+findComponentConfigs = findOfType('componentConfigs', models.ComponentConfig);
 findModelConfigs = findOfType('modelConfigs', models.ModelConfig);
 findModelDefinitions = findOfType('models', models.ModelDefinition);
 findViewDefinitions = findOfType('views', models.ViewDefinition);


### PR DESCRIPTION
Implement a new domain model "ComponentConfig" that represents entries in the project file server/component-config.json.

The model has two properties populated from the data in the JSON file:
 - name - the name of the component, e.g. "loopback-component-explorer"
 - value - the configuration of the component

Connect to #242

/to @ritch please review
/cc @raymondfeng @chayab