### PR TITLE
Add bluebird for tests running on v0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "better-stack-traces": "^1.0.1",
+    "bluebird": "^3.2.1",
     "chai": "^1.10.0",
     "grunt": "~0.4.5",
     "grunt-docular": "~0.1.2",

--- a/test/support.js
+++ b/test/support.js
@@ -8,6 +8,8 @@ var models = workspace.models;
 var ConfigFile = models.ConfigFile;
 var debug = require('debug')('workspace:test:support');
 
+global.Promise = require('bluebird');
+
 expectFileExists = function (file) {
   assert(fs.existsSync(file), file + ' does not exist');
 }


### PR DESCRIPTION
Fix the CI failures on Node v0.10 caused by #248 not setting up any Promise implementation.