### PR TITLE
Update dependencies

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -138,7 +138,7 @@ module.exports = function(Workspace) {
         }
       });
 
-      return _.merge.apply(_, sources);
+      return _.mergeWith.apply(_, sources);
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.2",
     "cookie-parser": "^1.3.2",
-    "debug": "~1.0.1",
+    "debug": "^2.2.0",
     "errorhandler": "^1.1.1",
-    "fs-extra": "~0.22.1",
-    "glob": "~4.0.2",
-    "lodash": "^3.0.0",
+    "fs-extra": "^0.30.0",
+    "glob": "^7.0.0",
+    "lodash": "^4.5.1",
     "loopback": "^2.0.0",
     "loopback-boot": "^2.0.0",
     "loopback-component-explorer": "^2.1.0",
@@ -41,14 +41,14 @@
     "bluebird": "^3.2.1",
     "chai": "^1.10.0",
     "eslint-config-loopback": "^2.0.0",
-    "grunt": "~0.4.5",
+    "grunt": "^1.0.0",
     "grunt-docular": "~0.1.2",
     "grunt-eslint": "^18.1.0",
     "grunt-loopback-sdk-angular": "~1.1.0",
-    "mocha": "^1.20.1",
+    "mocha": "^2.4.5",
     "mysql": "^2.4.2",
     "read": "^1.0.5",
     "strong-cached-install": "^2.0.0",
-    "supertest": "^0.13.0"
+    "supertest": "^1.2.0"
   }
 }


### PR DESCRIPTION
Update all dependencies to their latest (major) versions, with the exception of the following two dev dependencies:

 - `chai`, because they dropped function assertions in favour of property assertions
 - `grunt-docular`, because the module was always fragile and we don't use it much anyways