### PR TITLE
Add a new option - scaffold the project without loopback-component-explorer

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -18,6 +18,7 @@ module.exports = function(Workspace) {
 
     var PackageDefinition = app.models.PackageDefinition;
     var ConfigFile = app.models.ConfigFile;
+    var ComponentConfig = app.models.ComponentConfig;
     var Facet = app.models.Facet;
     var FacetSetting = app.models.FacetSetting;
     var ModelConfig = app.models.ModelConfig;
@@ -272,6 +273,14 @@ module.exports = function(Workspace) {
         steps.push(function(cb) {
           async.each(template.relations,
             ModelRelation.create.bind(ModelRelation), cb);
+        });
+      }
+
+      if (template.componentConfigs) {
+        setFacetName(template.componentConfigs);
+        steps.push(function(cb) {
+          async.each(template.componentConfigs,
+                     ComponentConfig.create.bind(ComponentConfig), cb);
         });
       }
 

--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -89,6 +89,15 @@ template.server = {
   ],
 
   datasources: [
+  ],
+
+  componentConfigs: [
+    {
+      name: 'loopback-component-explorer',
+      value: {
+        mountPath: '/explorer'
+      }
+    }
   ]
 };
 

--- a/templates/projects/empty-server/files/server/component-config.json
+++ b/templates/projects/empty-server/files/server/component-config.json
@@ -1,5 +1,0 @@
-{
-  "loopback-component-explorer": {
-    "mountPath": "/explorer"
-  }
-}

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -139,6 +139,13 @@ describe('end-to-end', function() {
         .get('/api/routes')
         .expect(404, done);
     });
+
+    it('comes with loopback-component-explorer', function(done) {
+      request(app).get('/explorer/swagger.json')
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .end(done);
+    });
   });
 
   describe('api-server template', function() {

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -148,6 +148,27 @@ describe('end-to-end', function() {
     });
   });
 
+  describe('empty-server template without explorer', function() {
+    before(resetWorkspace);
+    before(function createWorkspace(done) {
+      var options = {
+        'loopback-component-explorer': false,
+      };
+      givenWorkspaceFromTemplate('empty-server', options, done);
+    });
+
+    before(installSandboxPackages);
+
+    var app;
+    before(function loadApp() {
+      app = require(SANDBOX);
+    });
+
+    it('comes without loopback-component-explorer', function(done) {
+      request(app).get('/explorer/swagger.json').expect(404, done);
+    });
+  });
+
   describe('api-server template', function() {
     var app;
 

--- a/test/support.js
+++ b/test/support.js
@@ -83,11 +83,22 @@ givenBasicWorkspace = function(cb) {
   });
 }
 
-givenWorkspaceFromTemplate = function(template, cb) {
+givenWorkspaceFromTemplate = function(template, options, cb) {
+  if (cb === undefined && typeof options === 'function') {
+    cb = options;
+    options = undefined;
+  }
+
   givenEmptySandbox(function(err) {
-    if(err) return cb(err);
+    if (err) return cb(err);
     workspace.set('workspace dir', SANDBOX);
-    workspace.models.Workspace.createFromTemplate(template, 'sandbox', cb);
+    models.Workspace.createFromTemplate(template, 'sandbox', options,
+      function(err) {
+        if (err) return cb(err);
+        debug('Created %j in %s', template, SANDBOX);
+        cb();
+      }
+    );
   });
 }
 


### PR DESCRIPTION
- templates: move component config to data.js
- Modify `Workspace.createFromTemplate` to accept an optional `options` argument.
- Implement a new option to remove loopback-component-explorer from the scaffolded project (workspace).

Example usage:

```js
var opts = { 'loopback-component-explorer': false };
Workspace.createFromTemplate('api-server', 'myapp',  opts, cb);
```

Connect to strongloop/generator-loopback#153

/to @ritch please review