### PR TITLE
Add email-connector in `available-connectors.json`

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -27,6 +27,35 @@
       "discovery": false,
       "migration": false
     },
+    "settings":{
+      "transports": [{
+        "type": {
+          "type": "string"
+        },
+        "host": {
+          "type": "string"
+        },
+        "secure": {
+          "type": "boolean"
+        },
+        "port": {
+          "type": "number"
+        },
+        "tls": {
+          "rejectUnauthorized": {
+            "type": "boolean"
+          }
+        },
+        "auth": {
+          "user": {
+            "type": "string"
+          },
+          "pass": {
+            "type": "string"
+          }
+        }
+      }]
+    },
     "supportedByStrongLoop": true
   },
   {


### PR DESCRIPTION
###### Notice:
However, I believe We don't have support to read an array or objects inside an object  in `settings` for different connectors in `generator-loopback`; please see [here](https://github.com/strongloop/generator-loopback/blob/a8a49cdda819d5378cefcc525a19d859f5901374/datasource/index.js#L111-L179). If I'm right we should support them? Also, if we decide to add that support I guess we need to clarify our approaches...

Thanks  a lot Miroslav :-)

Connect to: https://github.ibm.com/apimesh/scrum-platform-foundation/issues/352