### PR TITLE
Fix regression due to change in delete API

### DIFF
--- a/common/models/model-definition.js
+++ b/common/models/model-definition.js
@@ -136,7 +136,11 @@ function ready(ModelDefinition) {
         async.parallel([
           removeModelDef,
           removeModelDefJs
-        ], cb);
+        ], function(err, results) {
+          if (err) return cb(err);
+
+          cb(null, {result: results});
+        });
       });
     });
   }


### PR DESCRIPTION
Fix regression due to change in the data format returned by deleteById.
Wrap the array returned by async.parallel into an object.