### PR TITLE
Added "schema" property for the DB2 Connector. Fixes #274.

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -47,6 +47,9 @@
       },
       "database": {
         "type": "string"
+      },
+      "schema": {
+        "type": "string"
       }
     },
     "package": {


### PR DESCRIPTION
The "schema" property is not included for the DB2 connector when creating a connector from the CLI or the UI.

@raymondfeng recommended I include the property here. I'm not sure if there are more properties that should be set, such as it being an optional property (I believe).