### PR TITLE
Fix Message extends Model

### DIFF
--- a/templates/projects/hello-world/files/common/models/message.json
+++ b/templates/projects/hello-world/files/common/models/message.json
@@ -1,5 +1,6 @@
 {
   "name": "Message",
+  "base": "Model",
   "properties": {},
   "methods": {
     "greet": {

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -426,6 +426,12 @@ describe('end-to-end', function() {
           done();
         });
     });
+
+    it('comes without built-in GET endpoint', function(done) {
+      request(app)
+        .get('/api/Messages')
+        .expect(404, done);
+    });
   });
 
   describe('autoupdate', function() {


### PR DESCRIPTION
A fix to https://github.com/strongloop/loopback-workspace/pull/278
@bajtos Sorry I realized that I didn't specify `Message` to extend `Model` instead of `PersistedModel` in the new hello-world template.

I fixed it in this pr. Please review, thanks!