### PR TITLE
Add MQ Light to available connectors

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -110,7 +110,7 @@
       "password": {
         "type": "string",
         "display": "password"
-      },
+      }
     },
     "package": {
       "name": "loopback-connector-dashdb",

--- a/available-connectors.json
+++ b/available-connectors.json
@@ -92,23 +92,17 @@
     "supportedByStrongLoop": true
   },
   {
-    "name": "dashdb",
-    "description": "IBM DashDB",
-    "baseModel": "PersistedModel",
+    "name": "mqlight",
+    "description": "IBM MQ Light",
+    "baseModel": "Model",
     "features": {
       "discovery": false,
       "migration": false
     },
     "settings": {
-      "dsn": {
+      "service": {
         "type": "string",
-        "description": "Connection String dsn to override other settings (eg: DATABASE=MY_DB;HOSTNAME=MY_HOST;PORT=MY_PORT;PROTOCOL=TCPIP;UID=MY_UID;PWD=MY_PWD))"
-      },
-      "host": {
-        "type": "string"
-      },
-      "port": {
-        "type": "number"
+        "description": "URL string for MQ Light service"
       },
       "user": {
         "type": "string"
@@ -117,9 +111,6 @@
         "type": "string",
         "display": "password"
       },
-      "database": {
-        "type": "string"
-      }
     },
     "package": {
       "name": "loopback-connector-dashdb",


### PR DESCRIPTION
@bajtos, I'm adding the new MQ Light connector to available-connectors and also fixing an issue from a previous PR which resulted in duplicate entries for dashDB