### PR TITLE
Add supportedLBVersion to metadata

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -50,6 +50,22 @@ module.exports = function(Workspace) {
      */
 
     /**
+     * Get list of available loopback Versions.
+     *
+     * @callback {Function} callback
+     * @param {Error} err
+     * @param {Object} availableLBVersions
+     */
+
+    Workspace.getAvailableLBVersions = function(cb) {
+      var availableLBVersions = {
+        '2.x': { description: 'stable' },
+        '3.x': { description: 'pre-release, alpha quality' },
+      };
+      cb(null, availableLBVersions);
+    };
+
+    /**
      * Get an array of available template names.
      *
      * @callback {Function} callback
@@ -90,6 +106,7 @@ module.exports = function(Workspace) {
           return {
             name: name,
             description: data.description,
+            supportedLBVersions: data.supportedLBVersions,
           };
         });
         cb(null, templates);
@@ -129,6 +146,7 @@ module.exports = function(Workspace) {
         var t = template.inherits[ix];
         var data = this._loadProjectTemplate(t);
         if (!data) return null; // the error was already reported
+        delete data.supportedLBVersions;
         sources.unshift(data);
       }
       /* eslint-enable one-var */

--- a/templates/projects/api-server/data.js
+++ b/templates/projects/api-server/data.js
@@ -6,6 +6,8 @@ var template = module.exports;
 
 template.description = 'A LoopBack API server with local User auth';
 
+template.supportedLBVersions = ['2.x', '3.x'];
+
 template.inherits = [
   'empty-server',
 ];

--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -7,6 +7,8 @@ var template = module.exports;
 template.description = 'An empty LoopBack API, without any configured ' +
   'models or datasources';
 
+template.supportedLBVersions = ['2.x', '3.x'];
+
 template.package = {
   'version': '1.0.0',
   'main': 'server/server.js',

--- a/templates/projects/hello-world/data.js
+++ b/templates/projects/hello-world/data.js
@@ -3,6 +3,8 @@ var template = module.exports;
 template.description = 'A project containing a controller, ' +
   'including a single vanilla Message and a single remote method';
 
+template.supportedLBVersions = ['2.x', '3.x'];
+
 template.inherits = [
   'empty-server',
 ];

--- a/templates/projects/notes/data.js
+++ b/templates/projects/notes/data.js
@@ -3,6 +3,8 @@ var template = module.exports;
 template.description = 'A project containing a basic working example, ' +
   'including a memory database';
 
+template.supportedLBVersions = ['2.x', '3.x'];
+
 template.inherits = [
   'empty-server',
 ];

--- a/test/workspace.js
+++ b/test/workspace.js
@@ -33,21 +33,25 @@ describe('Workspace', function() {
           {
             name: 'api-server',
             description: 'A LoopBack API server with local User auth',
+            supportedLBVersions: ['2.x', '3.x'],
           },
           {
             name: 'empty-server',
             description: 'An empty LoopBack API, without any configured ' +
               'models or datasources',
+            supportedLBVersions: ['2.x', '3.x'],
           },
           {
             description: 'A project containing a controller, ' +
               'including a single vanilla Message and a single remote method',
             name: 'hello-world',
+            supportedLBVersions: ['2.x', '3.x'],
           },
           {
             description: 'A project containing a basic working example, ' +
               'including a memory database',
             name: 'notes',
+            supportedLBVersions: ['2.x', '3.x'],
           },
         ]);
         done();


### PR DESCRIPTION
Connect to strongloop-internal/scrum-loopback#926

Related proposal: https://github.com/strongloop/generator-loopback/pull/207#issuecomment-227672375

In this pr:
[1]. I added a function called `getAvailableLBVersion` to return the available versions. Now it's hard-coded. Not sure is it worth to get info from npm or store the available versions in a file, like how we store available connectors.

[2]. I added metadata `supportedLBVersions` to each template.
There is a flag in the array because of the custom merge function:
https://github.com/strongloop/loopback-workspace/blob/master/common/models/workspace.js#L143
Array with flag `skipInherits` will ignore the value from parent template when merge.
And remove the flag when generating returned available templates.
Test cases added.
