### PR TITLE
Bump grunt-loopback-sdk-angular dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-loopback": "^2.0.0",
     "grunt": "^1.0.0",
     "grunt-docular": "~0.1.2",
-    "grunt-loopback-sdk-angular": "~1.1.0",
+    "grunt-loopback-sdk-angular": "^1.2.0",
     "mocha": "^2.4.5",
     "mysql": "^2.4.2",
     "read": "^1.0.5",


### PR DESCRIPTION
1) Use "^" to allow all minor version upgrades
2) Require 1.2 at minimum, to address issues caused by grunt 1.x release - see https://github.com/strongloop/grunt-loopback-sdk-angular/pull/23