### PR TITLE
Disable current-context in new projects

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -65,9 +65,7 @@ template.server = {
     { name: 'host', value: '0.0.0.0' }, // Listen on all interfaces
     { name: 'port', value: 3000 },
     { name: 'remoting', value: {
-      context: {
-        enableHttpContext: false,
-      },
+      context: false,
       rest: {
         normalizeHttpPath: false,
         xml: false,


### PR DESCRIPTION
The current implementation of current context in LoopBack is not good enough for general use because it has too many limitations.

This commit changes the template to disable current-context middleware via `remoting.context` option.

See also strongloop/loopback#2559 and strongloop/loopback#2564

/to @raymondfeng @ritch please review
/cc @0candy @jannyHou @richardpringle 