### PR TITLE
fix etag bug with xhr in chrome 52.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ var cookieParser = require('cookie-parser');
 var errorHandler = require('strong-error-handler');
 
 app.set('legacyExplorer', false);
+app.set('etag', false);
 
 // required to support base models
 app.dataSource('db', {


### PR DESCRIPTION
disable etag for workspace endpoint until
chrome fixes xhr 304/etag bug.

See https://bugs.chromium.org/p/chromium/issues/detail?id=633696
https://github.ibm.com/apimesh/scrum-api-editor/issues/788

@kraman PTAL
@ritch PTAL