### PR TITLE
Remove Legacy Explorer

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -215,6 +215,12 @@ module.exports = function(Workspace) {
             .filter(function(cc) { return cc.name != explorer; });
       }
 
+      // Add legacyExplorer flag to support creating LoopBack 2.x apps
+      if (loopbackVersion === '2.x' &&
+        template.server && template.server.config) {
+        template.server.config.push({ name: 'legacyExplorer', value: false });
+      }
+
       var dest = path.join(ConfigFile.getWorkspaceDir(), name);
       var steps = [];
 

--- a/server/server.js
+++ b/server/server.js
@@ -15,8 +15,6 @@ var boot = require('loopback-boot');
 var cookieParser = require('cookie-parser');
 var errorHandler = require('strong-error-handler');
 
-app.set('legacyExplorer', false);
-
 // required to support base models
 app.dataSource('db', {
   connector: loopback.Memory,

--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -82,7 +82,6 @@ template.server = {
       cors: false,
       handleErrors: false,
     }},
-    { name: 'legacyExplorer', value: false },
   ],
 
   modelConfigs: [

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -170,7 +170,6 @@ describe('end-to-end', function() {
             if (err) return done (err);
             var responseBody = JSON.stringify(res.body);
             expect(responseBody).to.include('stack');
-
             done();
           });
       });
@@ -509,6 +508,12 @@ describe('end-to-end', function() {
       expect(semver.gtr('3.0.0', dependencies.loopback)).to.be.false;
       done();
     });
+
+    it('comes without legacyExplorer flag in config.json', function(done) {
+      var config = fs.readJsonSync(path.resolve(SANDBOX, 'server/config.json'));
+      expect(config).to.not.have.property('legacyExplorer');
+      done();
+    });
   });
 
   describe('scaffold 2.x loopback project with option 2.x', function(done) {
@@ -523,6 +528,12 @@ describe('end-to-end', function() {
       expect(semver.gtr('3.0.0', dependencies.loopback)).to.be.true;
       expect(semver.gtr('3.0.0', dependencies['loopback-datasource-juggler']))
         .to.be.true;
+      done();
+    });
+
+    it('comes with legacyExplorer:false flag in config.json', function(done) {
+      var config = fs.readJsonSync(path.resolve(SANDBOX, 'server/config.json'));
+      expect(config).to.have.property('legacyExplorer', false);
       done();
     });
   });


### PR DESCRIPTION
- Removes `legacyExplorer` flag which
 enabled legacy end points: `/models` &
 `/routes`
- Update related tests & tests using the
legacyExplorer flag

Connect to https://github.com/strongloop/loopback/issues/2037