### PR TITLE
Handle non-string values in parseLoopBackVersion

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -10,6 +10,11 @@ exports.MASTER_LB_VERSION = '3.x';
  * @returns parse loopback version or default if invalid
  */
 exports.parseLoopBackVersion = function(version) {
+  // if the version isn't something meaningful to normalize-git-url,
+  // break and return the default to avoid a crash
+  if (typeof version !== 'string') {
+    return exports.DEFAULT_LB_VERSION;
+  }
   // If its a valid loopback version, return it
   var validRange = semver.validRange(version);
   if (validRange != null) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -33,5 +33,10 @@ describe('helper', function() {
       var version = helper.parseLoopBackVersion('dummy_value');
       expect(version).to.equal(helper.MASTER_LB_VERSION);
     });
+
+    it('non-string values should return default loopback version', function() {
+      var version = helper.parseLoopBackVersion();
+      expect(version).to.equal(helper.DEFAULT_LB_VERSION);
+    });
   });
 });


### PR DESCRIPTION
Add handler to avoid a crash when parseLoopBackVersion is called with
no argument, or a non-string value.