### PR TITLE
Fix "npm test" to not run MySQL setup outside CI

### DIFF
--- a/bin/setup-mysql.js
+++ b/bin/setup-mysql.js
@@ -16,6 +16,9 @@ DATABASE = 'loopback_workspace_test';
 USER = 'lbws';
 PASSWORD = 'hbx42rec';
 
+if (process.argv.indexOf('--ci-only') !== -1 && !process.env.CI)
+  return;
+
 var connection, password;
 async.series([
   function askForPassword(next) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "export-tests": true
   },
   "scripts": {
-    "pretest": "node bin/setup-mysql.js",
+    "pretest": "node bin/setup-mysql.js --ci-only",
     "lint": "eslint .",
     "test": "mocha",
     "posttest": "npm run lint"


### PR DESCRIPTION
The change introduced in #311 broke the behaviour of "npm test" when
running on a local developer's machine.

This commit adds a new switch "--ci-only" to "bin/setup-mysql" and
configures "npm test" to use this switch.

As a result, "npm test" does not trigger database setup when running
locally, but still triggers it when running on a CI server.

@0candy @jannyHou PTAL
cc @rmg 