### PR TITLE
[SEMVER-MAJOR] change the return types to match what they are

### DIFF
--- a/common/models/data-source-definition.js
+++ b/common/models/data-source-definition.js
@@ -173,7 +173,7 @@ function ready(DataSourceDefinition) {
     }, {
       arg: 'options', type: 'object',
     }],
-    returns: { arg: 'status', type: 'boolean' },
+    returns: { root: true, type: 'object' },
   });
 
   DataSourceDefinition.prototype.getDefaultBaseModel = function(cb) {
@@ -227,7 +227,7 @@ function ready(DataSourceDefinition) {
 
   loopback.remoteMethod(DataSourceDefinition.prototype.getSchema, {
     accepts: { arg: 'options', type: 'object' },
-    returns: { arg: 'models', type: 'array' },
+    returns: { root: true, type: 'array' },
   });
 
   DataSourceDefinition.prototype._setDefaultSchema = function(options) {


### PR DESCRIPTION
getSchema returned an object with one property, which was an array of
tables. There were no other properties returned.

discoverModelDefinition was returning an object so its return type was
completely wrong. Looks like it was copied from testConnection and not
updated.

This is a breaking change.