### PR TITLE
Remove unused properties for KV redis connector

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -48,12 +48,8 @@
       "port": {
         "type": "number"
       },
-      "user": {
-        "type": "string"
-      },
       "password": {
-        "type": "string",
-        "display": "password"
+        "type": "string"
       },
       "database": {
         "type": "string"


### PR DESCRIPTION
- `user` property is not in the downstream connector docs

@bajtos PTAL

Connect to https://github.com/strongloop/loopback-workspace/pull/332