### PR TITLE
Using 3.0.0 version of soap connector

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -456,7 +456,7 @@
     },
     "package": {
       "name": "loopback-connector-soap",
-      "version": "^2.4"
+      "version": "^3.0"
     },
     "settings": {
       "url": {


### PR DESCRIPTION
This change is to use 3.0.0 or higher version of loopback-connector-soap which is part of  loopback 3.0 release.

@bajtos PTAL
