### PR TITLE
Validate upserts

### DIFF
--- a/common/models/component-config.json
+++ b/common/models/component-config.json
@@ -6,6 +6,7 @@
     "component-config.json",
     "component-config.*.json"
   ],
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/config-file.json
+++ b/common/models/config-file.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "path": {
       "type": "string",

--- a/common/models/data-source-definition.json
+++ b/common/models/data-source-definition.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/database-column.json
+++ b/common/models/database-column.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "connector": {
       "type": "string"

--- a/common/models/definition.json
+++ b/common/models/definition.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "name": {
       "type": "string",

--- a/common/models/facet-setting.json
+++ b/common/models/facet-setting.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/facet.json
+++ b/common/models/facet.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "name": {
       "id": true,

--- a/common/models/middleware.json
+++ b/common/models/middleware.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/model-access-control.json
+++ b/common/models/model-access-control.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/model-config.json
+++ b/common/models/model-config.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/model-definition.json
+++ b/common/models/model-definition.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/model-method.json
+++ b/common/models/model-method.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/model-property.json
+++ b/common/models/model-property.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/model-relation.json
+++ b/common/models/model-relation.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/package-definition.json
+++ b/common/models/package-definition.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/property-validation.json
+++ b/common/models/property-validation.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "id": {
       "type": "string",

--- a/common/models/view-definition.json
+++ b/common/models/view-definition.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "model": "string"
   },

--- a/common/models/workspace-entity.json
+++ b/common/models/workspace-entity.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "configFile": {"type": "string", "json": false}
   }

--- a/common/models/workspace.json
+++ b/common/models/workspace.json
@@ -1,4 +1,5 @@
 {
+  "validateUpsert": true,
   "properties": {
     "name": {
       "id": true,


### PR DESCRIPTION
Enable `validateUpsert` on all models (workspace entities) to ensure validation is triggered for calls made by front-end UI (APIC Editor), which use `PUT` almost exclusively.

This should fix the problem where APIC Editor allows users to create a property name containing a dot, even though such value is not a valid name according to ModelProperty validation rules.

@jannyHou please review

@anthonyettinger or @eddiemonge could you please `npm install strongloop/loopback-workspace#fix/upsert-validation` in your APIC Editor codebase and do a quick check to verify that this change is not breaking any existing functionality?