### PR TITLE
Use 3.0 oracle connector version

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -373,7 +373,7 @@
     },
     "package": {
       "name": "loopback-connector-oracle",
-      "version": "^2.4"
+      "version": "^3.0"
     },
     "supportedByStrongLoop": true
   },


### PR DESCRIPTION
Switch loopback-workspace to use 3.0 version of oracle connector. This is part of LoopBack 3.0 release.  This version of Oracle connector has user experience improvement feature outlined in https://github.com/strongloop/loopback-connector-oracle/issues/79 
@bajtos or @raymondfeng PTAL
