### PR TITLE
4.x : Workspace Refactoring : Feature to add a datasource definition

### DIFF
--- a/common/models/data-source-definition.js
+++ b/common/models/data-source-definition.js
@@ -1,0 +1,25 @@
+// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Node module: loopback-workspace
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+'use strict';
+
+module.exports = function(DataSourceDefinition) {
+  /**
+   * Creates a data source definition.
+   *
+   * @class DataSourceDefinition
+   */
+  DataSourceDefinition.on('dataSourceAttached', function() {
+    DataSourceDefinition.create = function(data, options, cb) {
+      if (typeof options === 'function') {
+        cb = options;
+        options = null;
+      }
+      var connector = DataSourceDefinition.getConnector();
+      var id = data.id;
+      //TODO(Deepak) - add response handling later as part of the callback
+      connector.createDataSource(id, data, cb);
+    };
+  });
+};

--- a/common/models/data-source-definition.json
+++ b/common/models/data-source-definition.json
@@ -1,0 +1,35 @@
+{
+  "validateUpsert": true,
+  "properties": {
+    "id": {
+      "type": "string",
+      "id": true,
+      "json": false
+    },
+    "host": {
+      "type": "string"
+    },
+    "port": {
+      "type": "number"
+    },
+    "url": {
+      "type": "string"
+    },
+    "database": {
+      "type": "string"
+    },
+    "username": {
+      "type": "string"
+    },
+    "password": {
+      "type": "string"
+    },
+    "facetName": {
+      "type": "string",
+      "required": true,
+      "json": false
+    }
+  },
+  "public": true,
+  "dataSource": "db"
+}

--- a/component/datamodel/datasource.js
+++ b/component/datamodel/datasource.js
@@ -1,0 +1,17 @@
+'use strict';
+var Node = require('./graph').Node;
+
+/**
+ * @class DataSource
+ *
+ * Represents a DataSource artifact in the Workspace graph.
+ */
+class DataSource extends Node {
+  constructor(Workspace, id, datasource, options) {
+    super(Workspace, 'DataSource', id, datasource);
+    this.options = options;
+    Workspace.addNode(this);
+  }
+};
+
+module.exports = DataSource;

--- a/component/datamodel/graph/index.js
+++ b/component/datamodel/graph/index.js
@@ -21,20 +21,5 @@ class Graph {
     return this._cache[domain][name];
   }
 };
-
-/**
- * @class Node
- *
- * Node to represent an entity.
- */
-class Node {
-  constructor(graph, domain, name, data) {
-    this._graph = graph;
-    this._name = name;
-    this._content = data;
-    this._domain = domain;
-  }
-};
-
-exports.Graph = Graph;
-exports.Node = Node;
+module.exports = Graph;
+module.exports.Node = require('./node');

--- a/component/datamodel/graph/node.js
+++ b/component/datamodel/graph/node.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/**
+ * @class Node
+ *
+ * Node to represent an entity.
+ */
+class Node {
+  constructor(graph, domain, name, data) {
+    this._graph = graph;
+    this._name = name;
+    this._content = data;
+    this._domain = domain;
+  }
+};
+
+module.exports = Node;

--- a/component/datamodel/model.js
+++ b/component/datamodel/model.js
@@ -14,6 +14,7 @@ class Model extends Node {
     this.relations = {};
     this.config = {};
     this.options = options;
+    //Model adds itself to the workspace
     Workspace.addNode(this);
   }
 };

--- a/component/tasks.js
+++ b/component/tasks.js
@@ -1,5 +1,6 @@
 'use strict';
 var Model = require('./datamodel/model');
+var DataSource = require('./datamodel/datasource');
 
 /**
  * @class Tasks
@@ -10,8 +11,15 @@ var Model = require('./datamodel/model');
 class Tasks {
   addModel(modelId, modelDef, cb) {
     var workspace = this;
-    var model = new Model(workspace, modelId, modelDef);
+    //Model is a self-aware node which adds itself to the Workspace graph
+    new Model(workspace, modelId, modelDef);
     cb(null, modelDef);
+  }
+  addDataSource(id, datasource, cb) {
+    var workspace = this;
+    //Datasource is a self-aware node which adds itself to the Workspace graph
+    new DataSource(workspace, id, datasource);
+    cb(null, datasource);
   }
 };
 

--- a/component/workspace-manager.js
+++ b/component/workspace-manager.js
@@ -11,6 +11,7 @@ const Manager = class Manager {
     //TODO(Deepak) - use Path to resolve directory
     this.createWorkspace('/');
     this.workspace.addDomain('ModelDefinition');
+    this.workspace.addDomain('DataSource');
   }
   createWorkspace(dir) {
     this.workspace = new Workspace(dir);

--- a/component/workspace.js
+++ b/component/workspace.js
@@ -1,5 +1,5 @@
 'use strict';
-var Graph = require('./datamodel/graph.js').Graph;
+var Graph = require('./datamodel/graph');
 var Tasks = require('./tasks.js');
 
 /**
@@ -19,6 +19,10 @@ class Workspace extends Graph {
   getModel(modelId) {
     var model = this.getNode('ModelDefinition', modelId);
     return model._content;
+  }
+  getDataSource(id) {
+    var ds = this.getNode('DataSource', id);
+    return ds._content;
   }
 };
 

--- a/connector/connector.js
+++ b/connector/connector.js
@@ -12,3 +12,8 @@ connector.createModel = function(id, data, cb) {
   var workspace = WorkspaceManager.getWorkspace();
   workspace.addModel(id, data, cb);
 };
+
+connector.createDataSource = function(id, data, cb) {
+  var workspace = WorkspaceManager.getWorkspace();
+  workspace.addDataSource(id, data, cb);
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "cucumber": "^1.3.1",
+    "dirty-chai": "^1.2.2",
     "eslint": "^3.12.2",
     "eslint-config-loopback": "^6.1.0",
     "grunt": "^0.4.5",

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -9,6 +9,10 @@
       "./mixins"
     ]
   },
+  "DataSourceDefinition": {
+    "public": true,
+    "dataSource": "db"
+  },
   "ModelDefinition": {
     "public": true,
     "dataSource": "db"

--- a/test/acceptance-tests/workspace-devtime/create-datasource.feature
+++ b/test/acceptance-tests/workspace-devtime/create-datasource.feature
@@ -1,0 +1,10 @@
+Feature: Users should be able to create datasources 
+  As a workspace client using the EXAMPLE workspace
+  I want to create a DataSource in my workspace
+
+  Background: Workspace is loaded in a given directory
+
+  Scenario: Create a DataSource
+    Given that I have loaded the workspace
+    When I create datasource 'db' with connector 'memory'
+    Then the datasource definition is created

--- a/test/acceptance-tests/workspace-devtime/step-definitions/create-datasource.js
+++ b/test/acceptance-tests/workspace-devtime/step-definitions/create-datasource.js
@@ -1,0 +1,41 @@
+'use strict';
+var app = require('../../../../');
+var expect = require('../../../helpers/expect');
+var loopback = require('loopback');
+var path = require('path');
+var util = require('util');
+var workspaceManager = require('../../../../component/workspace-manager.js');
+var DataSourceDefinition = app.models.DataSourceDefinition;
+app.on('booted', function() {
+  app.emit('ready');
+});
+
+module.exports = function() {
+  var testsuite = this;
+  this.Given(/^that I have loaded the workspace$/, function(next) {
+    //TODO(DEEPAK) - modify here to load a particular workspace dir
+    next();
+  });
+
+  this.When(/^I create datasource '(.+)' with connector '(.+)'$/,
+    function(dsName, connector, next) {
+      testsuite.datasourceId = 'common.datasources.' + dsName;
+      var datasource = {
+        'id': testsuite.datasourceId,
+        'name': dsName,
+        'connector': connector,
+      };
+      DataSourceDefinition.create(datasource, {}, function(err, data) {
+        if (err) return next(err);
+        testsuite.expectedDs = datasource;
+        next();
+      });
+    });
+
+  this.Then(/^the datasource definition is created$/, function(next) {
+    var workspace = workspaceManager.getWorkspace();
+    var storedDs = workspace.getDataSource(testsuite.datasourceId);
+    expect(testsuite.expectedDs).to.eql(storedDs);
+    next();
+  });
+};

--- a/test/acceptance-tests/workspace-devtime/step-definitions/create-models.js
+++ b/test/acceptance-tests/workspace-devtime/step-definitions/create-models.js
@@ -1,6 +1,6 @@
 'use strict';
 var app = require('../../../../');
-var chai = require('chai');
+var expect = require('../../../helpers/expect');
 var loopback = require('loopback');
 var path = require('path');
 var util = require('util');
@@ -37,7 +37,6 @@ module.exports = function() {
   });
 
   this.Then(/^the model definition is created$/, function(next) {
-    var expect = chai.expect;
     var workspace = workspaceManager.getWorkspace();
     var storedModel = workspace.getModel(testsuite.modelId);
     expect(testsuite.expectedModel).to.eql(storedModel);

--- a/test/helpers/expect.js
+++ b/test/helpers/expect.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var chai = require('chai');
+chai.use(require('dirty-chai'));
+
+module.exports = chai.expect;


### PR DESCRIPTION
Create a datasource node in the workspace graph

- [X] - define a DataSource Class
- [X] - add a DataSourceDefinition loopback model
- [X] - add workspace task to add a Datasource node to a workspace graph
- [X] - extend connector to create a datasource
- [X] - add gherkin cucumber test case to create a datasource
- [X] - use Dirty Chai
- [X] - move graph modules in datamodel to sub directory 'graph'