### PR TITLE
4.x : Workspace Refactoring - Add a property to a model

### DIFF
--- a/common/models/data-source-definition.js
+++ b/common/models/data-source-definition.js
@@ -16,8 +16,8 @@ module.exports = function(DataSourceDefinition) {
         cb = options;
         options = null;
       }
-      var connector = DataSourceDefinition.getConnector();
-      var id = data.id;
+      const connector = DataSourceDefinition.getConnector();
+      const id = data.id;
       //TODO(Deepak) - add response handling later as part of the callback
       connector.createDataSource(id, data, cb);
     };

--- a/common/models/model-definition.js
+++ b/common/models/model-definition.js
@@ -11,13 +11,13 @@ module.exports = function(ModelDefinition) {
    * @class ModelDefinition
    */
   ModelDefinition.on('dataSourceAttached', function(eventData) {
-    var connector = ModelDefinition.getConnector();
+    const connector = ModelDefinition.getConnector();
     ModelDefinition.create = function(data, options, cb) {
       if (typeof options === 'function') {
         cb = options;
         options = null;
       }
-      var id = data.id;
+      const id = data.id;
       //TODO(Deepak) - add response handling later
       connector.createModel(id, data, cb);
     };

--- a/common/models/model-property.js
+++ b/common/models/model-property.js
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Node module: loopback-workspace
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+'use strict';
+
+/**
+  * Represents a Property of a LoopBack `Model`.
+  *
+  * @class ModelProperty
+  */
+module.exports = function(ModelProperty) {
+  ModelProperty.validatesFormatOf('name', {with: /^[\-_a-zA-Z0-9]+$/});
+
+  /**
+   * List of built-in types that can be used for `ModelProperty.type`.
+   * @type {string[]}
+   */
+  ModelProperty.availableTypes = [
+    'string',
+    'number',
+    'boolean',
+    'object',
+    'array',
+    'date',
+    'buffer',
+    'geopoint',
+    'any',
+  ];
+
+  ModelProperty.getAvailableTypes = function(cb) {
+    cb(null, ModelProperty.availableTypes);
+  };
+
+  ModelProperty.remoteMethod('getAvailableTypes', {
+    http: {verb: 'get', path: '/available-types'},
+    returns: {type: ['string'], root: true},
+  });
+
+  ModelProperty.on('dataSourceAttached', function(eventData) {
+    ModelProperty.create = function(data, options, cb) {
+      if (typeof options === 'function') {
+        cb = options;
+        options = null;
+      }
+      const connector = ModelProperty.getConnector();
+      const id = data.id;
+      const tokens = id.split('.');
+      if (tokens && tokens.length === 3) {
+        const facet = tokens[0];
+        const modelName = tokens[1];
+        const propertyName = tokens[2];
+        const modelId = facet + '.' + modelName;
+        connector.createModelProperty(modelId, propertyName, data, cb);
+      } else {
+        return cb('invalid id field');
+      }
+    };
+  });
+};

--- a/common/models/model-property.json
+++ b/common/models/model-property.json
@@ -1,0 +1,43 @@
+{
+  "validateUpsert": true,
+  "properties": {
+    "id": {
+      "type": "string",
+      "id": true,
+      "json": false
+    },
+    "modelId": {
+      "type": "string",
+      "required": true,
+      "json": false
+    },
+    "facetName": {
+      "type": "string",
+      "required": true,
+      "json": false
+    },
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "type": "any"
+    },
+    "isId": {
+      "type": "boolean",
+      "json": "id"
+    },
+    "generated": {
+      "type": "boolean"
+    },
+    "required": {
+      "type": "boolean"
+    },
+    "index": {
+      "type": "boolean"
+    },
+    "description": {
+      "type": "string"
+    }
+  },
+  "public": true
+}

--- a/component/datamodel/datasource.js
+++ b/component/datamodel/datasource.js
@@ -1,5 +1,5 @@
 'use strict';
-var Node = require('./graph').Node;
+const Node = require('./graph').Node;
 
 /**
  * @class DataSource

--- a/component/datamodel/graph/index.js
+++ b/component/datamodel/graph/index.js
@@ -13,8 +13,8 @@ class Graph {
     this._cache[name] = {};
   }
   addNode(node) {
-    var domain = node._domain;
-    var name = node._name;
+    const domain = node._domain;
+    const name = node._name;
     this._cache[domain][name] = node;
   }
   getNode(domain, name) {

--- a/component/datamodel/model-property.js
+++ b/component/datamodel/model-property.js
@@ -1,0 +1,17 @@
+'use strict';
+const Node = require('./graph').Node;
+
+/**
+ * @class ModelProperty
+ *
+ * Represents a ModelProperty artifact in the Workspace graph.
+ */
+class ModelProperty extends Node {
+  constructor(Workspace, id, propertyDef, options) {
+    super(Workspace, 'ModelProperty', id, propertyDef);
+    //ModelProperty adds itself to the workspace
+    Workspace.addNode(this);
+  }
+};
+
+module.exports = ModelProperty;

--- a/component/datamodel/model.js
+++ b/component/datamodel/model.js
@@ -1,5 +1,5 @@
 'use strict';
-var Node = require('./graph').Node;
+const Node = require('./graph').Node;
 
 /**
  * @class Model
@@ -16,6 +16,9 @@ class Model extends Node {
     this.options = options;
     //Model adds itself to the workspace
     Workspace.addNode(this);
+  }
+  setProperty(name, property) {
+    this.properties[name] = property;
   }
 };
 

--- a/component/tasks.js
+++ b/component/tasks.js
@@ -1,6 +1,7 @@
 'use strict';
-var Model = require('./datamodel/model');
-var DataSource = require('./datamodel/datasource');
+const Model = require('./datamodel/model');
+const ModelProperty = require('./datamodel/model-property');
+const DataSource = require('./datamodel/datasource');
 
 /**
  * @class Tasks
@@ -10,16 +11,25 @@ var DataSource = require('./datamodel/datasource');
  */
 class Tasks {
   addModel(modelId, modelDef, cb) {
-    var workspace = this;
+    const workspace = this;
     //Model is a self-aware node which adds itself to the Workspace graph
     new Model(workspace, modelId, modelDef);
     cb(null, modelDef);
   }
   addDataSource(id, datasource, cb) {
-    var workspace = this;
+    const workspace = this;
     //Datasource is a self-aware node which adds itself to the Workspace graph
     new DataSource(workspace, id, datasource);
     cb(null, datasource);
+  }
+  addModelProperty(modelId, propertyName, propertyDef, cb) {
+    const workspace = this;
+    const id = modelId + '.' + propertyName;
+    //ModelProperty is a self-aware node which adds itself to the Workspace graph
+    const property = new ModelProperty(workspace, id, propertyDef);
+    const model = workspace.getModel(modelId);
+    model.setProperty(propertyName, property);
+    cb(null, propertyDef);
   }
 };
 

--- a/component/workspace-manager.js
+++ b/component/workspace-manager.js
@@ -1,5 +1,5 @@
 'use strict';
-var Workspace = require('./workspace.js');
+const Workspace = require('./workspace.js');
 
 /**
  * @class WorkspaceManager
@@ -12,6 +12,7 @@ const Manager = class Manager {
     this.createWorkspace('/');
     this.workspace.addDomain('ModelDefinition');
     this.workspace.addDomain('DataSource');
+    this.workspace.addDomain('ModelProperty');
   }
   createWorkspace(dir) {
     this.workspace = new Workspace(dir);

--- a/component/workspace.js
+++ b/component/workspace.js
@@ -1,6 +1,6 @@
 'use strict';
-var Graph = require('./datamodel/graph');
-var Tasks = require('./tasks.js');
+const Graph = require('./datamodel/graph');
+const Tasks = require('./tasks.js');
 
 /**
  * @class Workspace
@@ -17,20 +17,24 @@ class Workspace extends Graph {
     mixin(this, Tasks.prototype);
   }
   getModel(modelId) {
-    var model = this.getNode('ModelDefinition', modelId);
-    return model._content;
+    const model = this.getNode('ModelDefinition', modelId);
+    return model;
   }
   getDataSource(id) {
-    var ds = this.getNode('DataSource', id);
-    return ds._content;
+    const ds = this.getNode('DataSource', id);
+    return ds;
+  }
+  getModelProperty(id) {
+    const property = this.getNode('ModelProperty', id);
+    return property;
   }
 };
 
 function mixin(target, source) {
-  var attributes = Object.getOwnPropertyNames(source);
+  const attributes = Object.getOwnPropertyNames(source);
   attributes.forEach(function(ix) {
     if (typeof source[ix] === 'function') {
-      var mx = source[ix];
+      const mx = source[ix];
       target[ix] = mx;
     }
   });

--- a/connector/connector.js
+++ b/connector/connector.js
@@ -1,7 +1,7 @@
 'use strict';
-var app = require('../server/server.js');
-var connector = app.dataSources.db.connector;
-var WorkspaceManager = require('../component/workspace-manager.js');
+const app = require('../server/server.js');
+const connector = app.dataSources.db.connector;
+const WorkspaceManager = require('../component/workspace-manager.js');
 
 /**
  * @class Connector
@@ -9,11 +9,16 @@ var WorkspaceManager = require('../component/workspace-manager.js');
  * performs CRUD operations on the Workspace graph.
  */
 connector.createModel = function(id, data, cb) {
-  var workspace = WorkspaceManager.getWorkspace();
+  const workspace = WorkspaceManager.getWorkspace();
   workspace.addModel(id, data, cb);
 };
 
 connector.createDataSource = function(id, data, cb) {
-  var workspace = WorkspaceManager.getWorkspace();
+  const workspace = WorkspaceManager.getWorkspace();
   workspace.addDataSource(id, data, cb);
+};
+
+connector.createModelProperty = function(modelId, propertyName, data, cb) {
+  const workspace = WorkspaceManager.getWorkspace();
+  workspace.addModelProperty(modelId, propertyName, data, cb);
 };

--- a/server/model-config.json
+++ b/server/model-config.json
@@ -16,6 +16,10 @@
   "ModelDefinition": {
     "public": true,
     "dataSource": "db"
+  },
+  "ModelProperty": {
+    "public": true,
+    "dataSource": "db"
   }
 }
 

--- a/test/acceptance-tests/workspace-devtime/create-models.feature
+++ b/test/acceptance-tests/workspace-devtime/create-models.feature
@@ -8,4 +8,8 @@ Feature: Users should be able to create models
     Given that I have loaded the workspace
     When I create model 'Customer'
     Then the model definition is created
-    
+  
+  Scenario: Add a property to the model
+    Given the model 'Customer' exists
+    When I add property 'name' of type 'string'
+    Then the model property is created

--- a/test/acceptance-tests/workspace-devtime/step-definitions/create-datasource.js
+++ b/test/acceptance-tests/workspace-devtime/step-definitions/create-datasource.js
@@ -1,17 +1,18 @@
 'use strict';
-var app = require('../../../../');
-var expect = require('../../../helpers/expect');
-var loopback = require('loopback');
-var path = require('path');
-var util = require('util');
-var workspaceManager = require('../../../../component/workspace-manager.js');
-var DataSourceDefinition = app.models.DataSourceDefinition;
+const app = require('../../../../');
+const expect = require('../../../helpers/expect');
+const loopback = require('loopback');
+const path = require('path');
+const util = require('util');
+const workspaceManager = require('../../../../component/workspace-manager');
+
+const DataSourceDefinition = app.models.DataSourceDefinition;
 app.on('booted', function() {
   app.emit('ready');
 });
 
 module.exports = function() {
-  var testsuite = this;
+  const testsuite = this;
   this.Given(/^that I have loaded the workspace$/, function(next) {
     //TODO(DEEPAK) - modify here to load a particular workspace dir
     next();
@@ -20,7 +21,7 @@ module.exports = function() {
   this.When(/^I create datasource '(.+)' with connector '(.+)'$/,
     function(dsName, connector, next) {
       testsuite.datasourceId = 'common.datasources.' + dsName;
-      var datasource = {
+      const datasource = {
         'id': testsuite.datasourceId,
         'name': dsName,
         'connector': connector,
@@ -33,9 +34,9 @@ module.exports = function() {
     });
 
   this.Then(/^the datasource definition is created$/, function(next) {
-    var workspace = workspaceManager.getWorkspace();
-    var storedDs = workspace.getDataSource(testsuite.datasourceId);
-    expect(testsuite.expectedDs).to.eql(storedDs);
+    const workspace = workspaceManager.getWorkspace();
+    const storedDs = workspace.getDataSource(testsuite.datasourceId);
+    expect(testsuite.expectedDs).to.eql(storedDs._content);
     next();
   });
 };

--- a/test/acceptance-tests/workspace-devtime/step-definitions/create-models.js
+++ b/test/acceptance-tests/workspace-devtime/step-definitions/create-models.js
@@ -1,17 +1,20 @@
 'use strict';
-var app = require('../../../../');
-var expect = require('../../../helpers/expect');
-var loopback = require('loopback');
-var path = require('path');
-var util = require('util');
-var workspaceManager = require('../../../../component/workspace-manager.js');
-var ModelDefinition = app.models.ModelDefinition;
+const app = require('../../../../');
+const expect = require('../../../helpers/expect');
+const loopback = require('loopback');
+const ModelClass = require('../../../../component/datamodel/model');
+const path = require('path');
+const util = require('util');
+const workspaceManager = require('../../../../component/workspace-manager');
+
+const ModelDefinition = app.models.ModelDefinition;
+const ModelProperty = app.models.ModelProperty;
 app.on('booted', function() {
   app.emit('ready');
 });
 
 module.exports = function() {
-  var testsuite = this;
+  const testsuite = this;
   this.Given(/^that I have loaded the workspace$/, function(next) {
     //TODO(DEEPAK) - modify here to load a particular workspace dir
     next();
@@ -19,7 +22,7 @@ module.exports = function() {
 
   this.When(/^I create model '(.+)'$/, function(modelName, next) {
     testsuite.modelId = 'common.' + modelName;
-    var model = {
+    const model = {
       'id': testsuite.modelId,
       'name': modelName,
       'readonly': true,
@@ -37,9 +40,40 @@ module.exports = function() {
   });
 
   this.Then(/^the model definition is created$/, function(next) {
-    var workspace = workspaceManager.getWorkspace();
-    var storedModel = workspace.getModel(testsuite.modelId);
-    expect(testsuite.expectedModel).to.eql(storedModel);
+    const workspace = workspaceManager.getWorkspace();
+    const storedModel = workspace.getModel(testsuite.modelId);
+    expect(testsuite.expectedModel).to.eql(storedModel._content);
+    next();
+  });
+
+  this.Given(/^the model '(.+)' exists$/, function(modelName, next) {
+    testsuite.modelId = 'common.' + modelName;
+    const workspace = workspaceManager.getWorkspace();
+    const storedModel = workspace.getModel(testsuite.modelId);
+    expect(storedModel).to.not.to.be.undefined();
+    expect(storedModel).to.be.an.instanceOf(ModelClass);
+    next();
+  });
+
+  this.When(/^I add property '(.+)' of type '(.+)'$/,
+    function(propertyName, type, next) {
+      testsuite.propertyId = testsuite.modelId + '.' + propertyName;
+      const propertyDef = {
+        'id': testsuite.propertyId,
+        'name': propertyName,
+        'type': type,
+      };
+      ModelProperty.create(propertyDef, {}, function(err, data) {
+        if (err) return next(err);
+        testsuite.expectedProperty = propertyDef;
+        next();
+      });
+    });
+
+  this.Then(/^the model property is created$/, function(next) {
+    const workspace = workspaceManager.getWorkspace();
+    const property = workspace.getModelProperty(testsuite.propertyId);
+    expect(testsuite.expectedProperty).to.eql(property._content);
     next();
   });
 };

--- a/test/helpers/expect.js
+++ b/test/helpers/expect.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var chai = require('chai');
-chai.use(require('dirty-chai'));
+const chai = require('chai');
+const dirtyChai = require('dirty-chai');
 
-module.exports = chai.expect;
+chai.use(dirtyChai);
+const expect = chai.expect;
+
+module.exports = expect;


### PR DESCRIPTION
Feature to add a model property to a workspace graph
- [X] - add a model-property loopback model
- [X] - add method to connector to handle createModelProperty
- [X] - add a method to workspace tasks for addModelProperty
- [X] - create a new class for model property in workspace graph
- [X] - add a new gherkin cucumber test case