### PR TITLE
Fix handleErrors config in the template

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -67,6 +67,7 @@ template.server = {
     { name: 'remoting', value: {
       context: false,
       rest: {
+        handleErrors: false,
         normalizeHttpPath: false,
         xml: false,
       },
@@ -79,7 +80,6 @@ template.server = {
         limit: '100kb',
       },
       cors: false,
-      handleErrors: false,
     }},
   ],
 


### PR DESCRIPTION
Fix "empty-server" template to correctly disable the built-in error handler provided by REST adapter in strong-remoting.

See https://github.com/strongloop/loopback.io/pull/134 and https://github.com/strongloop/loopback.io/pull/134#issuecomment-270097859 in particular for background information.

@superkhau please review
cc @doublemarked