### PR TITLE
update grammar to remove `you` references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ var workspace = require('loopback-workspace');
 
 **Custom Workspace Directory**
 
-To start the workspace in a specific directory, you must specify the
-`WORKSPACE_DIR` env variable.
+To start the workspace in a specific directory, specify the `WORKSPACE_DIR` env
+variable.
 
 **REST**
 
-In order to use the REST api, you must mount the app on an existing express app
-or call `workspace.listen(PORT)`.
+In order to use the REST api, mount the app on an existing express app or call
+`workspace.listen(PORT)`.
 
 ## Test
 


### PR DESCRIPTION
For instructional type docs, use of `you` is often frowned upon. [Reference](http://en.writecheck.com/blog/2012/11/30/writing-no-no-1-video)