### PR TITLE
Enable "logoutSessionsOnSensitiveChanges" for LB 2.x projects

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -217,10 +217,16 @@ module.exports = function(Workspace) {
             .filter(function(cc) { return cc.name != explorer; });
       }
 
-      // Add legacyExplorer flag to support creating LoopBack 2.x apps
+      // Add LoopBack 2.x specific flags to preven warnings on startup
       if (loopbackVersion === '2.x' &&
         template.server && template.server.config) {
+        // Disable legacy routes describing remote methods
         template.server.config.push({ name: 'legacyExplorer', value: false });
+        // Enable AccessToken invalidation on email/password change
+        template.server.config.push({
+          name: 'logoutSessionsOnSensitiveChanges',
+          value: true,
+        });
       }
 
       var dest = path.join(ConfigFile.getWorkspaceDir(), name);

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -154,14 +154,10 @@ describe('end-to-end', function() {
     });
 
     it('includes sensitive error details in development mode', function(done) {
-      var loopback = require(SANDBOX + '/node_modules/loopback');
-      var boot = require(SANDBOX + '/node_modules/loopback-boot');
-      var app = loopback({ localRegistry: true, loadBuiltinModels: true });
       var bootOptions = {
-        appRootDir: SANDBOX + '/server',
         env: 'development',
       };
-      boot(app, bootOptions, function(err) {
+      bootSandboxWithOptions(bootOptions, function(err, app) {
         if (err) return done(err);
         request(app)
           .get('/url-does-not-exist')
@@ -176,14 +172,10 @@ describe('end-to-end', function() {
     });
 
     it('omits sensitive error details in production mode', function(done) {
-      var loopback = require(SANDBOX + '/node_modules/loopback');
-      var boot = require(SANDBOX + '/node_modules/loopback-boot');
-      var app = loopback({ localRegistry: true, loadBuiltinModels: true });
       var bootOptions = {
-        appRootDir: SANDBOX + '/server',
         env: 'production',
       };
-      boot(app, bootOptions, function(err) {
+      bootSandboxWithOptions(bootOptions, function(err, app) {
         if (err) return done(err);
         request(app)
           .get('/url-does-not-exist')
@@ -203,16 +195,12 @@ describe('end-to-end', function() {
     });
 
     it('disables built-in REST error handler', function(done) {
-      var loopback = require(SANDBOX + '/node_modules/loopback');
-      var boot = require(SANDBOX + '/node_modules/loopback-boot');
-      var app = loopback({ localRegistry: true, loadBuiltinModels: true });
       var bootOptions = {
-        appRootDir: SANDBOX + '/server',
         // In "production", strong-error-handler hides error messages too,
         // while the built-in REST error handler does not
         env: 'production',
       };
-      boot(app, bootOptions, function(err) {
+      bootSandboxWithOptions(bootOptions, function(err, app) {
         if (err) return done(err);
 
         // create a model with a custom remote method returning a 500 error
@@ -1184,4 +1172,17 @@ function readBuiltinPhasesFromSanbox() {
   var app = loopback();
   app.lazyrouter(); // initialize request handling phases
   return app._requestHandlingPhases;
+}
+
+function bootSandboxWithOptions(options, done) {
+  var loopback = require(SANDBOX + '/node_modules/loopback');
+  var boot = require(SANDBOX + '/node_modules/loopback-boot');
+  var app = loopback({ localRegistry: true, loadBuiltinModels: true });
+  var bootOptions = extend({
+    appRootDir: SANDBOX + '/server',
+  }, options);
+
+  boot(app, bootOptions, function(err) {
+    done(err, app);
+  });
 }


### PR DESCRIPTION
### Description

- test cleanup: extract bootSandboxWithOptions()
- Modify "empty-server" template to enable
 "logoutSessionsOnSensitiveChanges" for projects using on LoopBack 2.x

#### Related issues

- https://github.com/strongloop/loopback/issues/3068
- requires https://github.com/strongloop/loopback/pull/3109 to be landed and released first

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
