### PR TITLE
Fix CI Errors in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "glob": "^7.0.0",
     "lodash": "^4.5.1",
     "loopback": "^2.0.0",
-    "loopback-boot": "^2.0.0",
-    "loopback-component-explorer": "^3.0.1",
+    "loopback-boot": "^2.6.5",
+    "loopback-component-explorer": "^2.1.0",
     "loopback-datasource-juggler": "^2.27.0",
     "method-override": "^2.1.1",
     "morgan": "^1.2.0",
@@ -50,7 +50,6 @@
     "mocha": "^2.4.5",
     "mysql": "^2.4.2",
     "read": "^1.0.5",
-    "strong-cached-install": "^2.0.0",
     "supertest": "^1.2.0"
   }
 }

--- a/test/helpers/platform.js
+++ b/test/helpers/platform.js
@@ -1,0 +1,8 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback-connector-mysql
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+'use strict';
+
+exports.isWindows = /^win/.test(process.platform);


### PR DESCRIPTION
Fix Windows CI Errors:

- [x] - remove cached install
- [x] - add 'npm install' in sandbox
- [x] - initialize sandbox with 'node_modules' folder 
- [x] - loopback-workspace should use latest loopback-boot
