### PR TITLE
4.x : Add relations between workspace API

### DIFF
--- a/common/models/model-definition.js
+++ b/common/models/model-definition.js
@@ -21,12 +21,21 @@ module.exports = function(ModelDefinition) {
       // TODO(Deepak) - add response handling later
       connector.createModel(options.workspaceId, id, data, cb);
     };
-    ModelDefinition.find = function(filter, options, cb) {
+    ModelDefinition.findById = function(filter, options, cb) {
       if (typeof options === 'function') {
         cb = options;
         options = {};
       }
       const id = filter.where.id;
+      const connector = ModelDefinition.getConnector();
+      connector.findModel(options.workspaceId, id, cb);
+    };
+    ModelDefinition.all = function(filter, options, cb) {
+      if (typeof options === 'function') {
+        cb = options;
+        options = {};
+      }
+      const id = filter.where && filter.where.id;
       const connector = ModelDefinition.getConnector();
       connector.findModel(options.workspaceId, id, cb);
     };

--- a/common/models/model-definition.json
+++ b/common/models/model-definition.json
@@ -5,11 +5,6 @@
       "id": true,
       "json": false
     },
-    "workspaceId": {
-      "type": "string",
-      "required": true,
-      "json": false
-    },
     "facetName": {
       "type": "string",
       "required": true,
@@ -37,6 +32,12 @@
     "scopes": "object",
     "indexes": "object"
   },
-  "public": true,
+  "relations": {
+    "properties": {
+      "type": "hasMany",
+      "model": "ModelProperty",
+      "foreignKey": "modelId"
+    }
+  },
   "http": {"path": "/Workspace/:workspaceId/ModelDefinition"}
 }

--- a/common/models/model-property.js
+++ b/common/models/model-property.js
@@ -62,5 +62,14 @@ module.exports = function(ModelProperty) {
       const connector = ModelProperty.getConnector();
       connector.findModelProperty(options.workspaceId, id, cb);
     };
+    ModelProperty.all = function(filter, options, cb) {
+      if (typeof options === 'function') {
+        cb = options;
+        options = {};
+      }
+      const id = filter.where.id;
+      const connector = ModelProperty.getConnector();
+      connector.findModelProperty(options.workspaceId, id, cb);
+    };
   });
 };

--- a/common/models/model-property.json
+++ b/common/models/model-property.json
@@ -6,11 +6,6 @@
       "id": true,
       "json": false
     },
-    "workspaceId": {
-      "type": "string",
-      "required": true,
-      "json": false
-    },
     "modelId": {
       "type": "string",
       "required": true,
@@ -45,5 +40,12 @@
     }
   },
   "public": true,
-  "http": {"path": "/Workspace/:workspaceId/ModelProperty"}
+  "http": {"path": "/Workspace/:workspaceId/ModelProperty"},
+  "relations": {
+    "model": {
+      "type": "belongsTo",
+      "model": "ModelDefinition",
+      "foreignKey": "modelId"
+    }
+  }
 }

--- a/common/models/workspace.json
+++ b/common/models/workspace.json
@@ -2,11 +2,11 @@
   "properties": {
     "templateName": {
       "type": "string",
-      "id": true,
       "json": false
     },
     "workspaceId": {
       "type": "string",
+      "id": true,
       "required": true,
       "json": false
     },

--- a/component/datamodel/model.js
+++ b/component/datamodel/model.js
@@ -36,6 +36,9 @@ class Model extends Entity {
   getRelation(relationName) {
     return this.getContainedNode(relationName);
   }
+  getContents() {
+    return clone(this._content);
+  }
   getDefinition() {
     const model = this;
 

--- a/component/workspace.js
+++ b/component/workspace.js
@@ -97,6 +97,10 @@ class Workspace extends Graph {
     const ds = this._cache['DataSource'];
     return ds;
   }
+  getAllModels() {
+    const models = this._cache['ModelDefinition'];
+    return models;
+  }
   setDatasources(config) {
     const workspace = this;
     const datasources = this._cache['DataSource'];

--- a/connector/index.js
+++ b/connector/index.js
@@ -16,6 +16,15 @@ const WorkspaceManager = require('../component/workspace-manager.js');
  *
  * performs CRUD operations on the Workspace graph.
  */
+connector.all = function(modelName, filter, options, cb) {
+  const model = app.models[modelName];
+  model.all(filter, options, cb);
+};
+
+connector.create = function(modelName, data, options, cb) {
+  const model = app.models[modelName];
+  model.create(data, options, cb);
+};
 
 connector.createFromTemplate = function(template, destinationFolder, cb) {
   const workspace = WorkspaceManager.createWorkspace(destinationFolder);
@@ -97,7 +106,10 @@ connector.createModel = function(workspaceId, id, data, cb) {
 
 connector.findModel = function(workspaceId, id, cb) {
   const workspace = WorkspaceManager.getWorkspace(workspaceId);
-  ModelHandler.findModel(workspace, id, cb);
+  if (id)
+    ModelHandler.findModel(workspace, id, cb);
+  else
+    ModelHandler.findAllModels(workspace, cb);
 };
 
 connector.findModelConfig = function(workspaceId, id, cb) {

--- a/connector/workspace-handler.js
+++ b/connector/workspace-handler.js
@@ -15,27 +15,47 @@ class WorkspaceHandler {
 
     facetConfigFiles.forEach(function(filePath) {
       taskList.push(function(next) {
-        handler.loadFacet(workspace, filePath, erroredFiles, next);
+        handler.loadFacet(workspace, filePath, function(err) {
+          if (err)
+            erroredFiles.push({file: filePath, error: err});
+          next();
+        });
       });
     });
     modelFiles.forEach(function(filePath) {
       taskList.push(function(next) {
-        handler.loadModelDefinition(workspace, filePath, erroredFiles, next);
+        handler.loadModelDefinition(workspace, filePath, function(err) {
+          if (err)
+            erroredFiles.push({file: filePath, error: err});
+          next();
+        });
       });
     });
     dataSourceFiles.forEach(function(filePath) {
       taskList.push(function(next) {
-        handler.loadDataSources(workspace, filePath, erroredFiles, next);
+        handler.loadDataSources(workspace, filePath, function(err) {
+          if (err)
+            erroredFiles.push({file: filePath, error: err});
+          next();
+        });
       });
     });
     modelConfigFiles.forEach(function(filePath) {
       taskList.push(function(next) {
-        handler.loadModelConfig(workspace, filePath, erroredFiles, next);
+        handler.loadModelConfig(workspace, filePath, function(err) {
+          if (err)
+            erroredFiles.push({file: filePath, error: err});
+          next();
+        });
       });
     });
     middlewareFiles.forEach(function(filePath) {
       taskList.push(function(next) {
-        handler.loadMiddleware(workspace, filePath, erroredFiles, next);
+        handler.loadMiddleware(workspace, filePath, function(err) {
+          if (err)
+            erroredFiles.push({file: filePath, error: err});
+          next();
+        });
       });
     });
     return taskList;
@@ -57,39 +77,24 @@ class WorkspaceHandler {
       workspace.execute(taskList, callback);
     });
   }
-  static loadModelDefinition(workspace, filePath, erroredFiles, next) {
+  static loadModelDefinition(workspace, filePath, cb) {
     const modelFilePath = path.join(workspace.getDirectory(), filePath);
     fsUtility.readFile(modelFilePath, function(err, fileData) {
-      if (err) return next(err);
-      workspace.loadModel(filePath, fileData, function(err) {
-        if (err) erroredFiles.push(err);
-        next();
-      });
+      if (err) return cb(err);
+      workspace.loadModel(filePath, fileData, cb);
     });
   }
-  static loadDataSources(workspace, filePath, erroredFiles, next) {
-    workspace.loadDataSources(filePath, function(err) {
-      if (err) erroredFiles.push(err);
-      next();
-    });
+  static loadDataSources(workspace, filePath, cb) {
+    workspace.loadDataSources(filePath, cb);
   }
-  static loadModelConfig(workspace, filePath, erroredFiles, next) {
-    workspace.loadModelConfig(filePath, function(err) {
-      if (err) erroredFiles.push(err);
-      next();
-    });
+  static loadModelConfig(workspace, filePath, cb) {
+    workspace.loadModelConfig(filePath, cb);
   }
-  static loadMiddleware(workspace, filePath, erroredFiles, next) {
-    workspace.loadMiddleware(filePath, function(err) {
-      if (err) erroredFiles.push(err);
-      next();
-    });
+  static loadMiddleware(workspace, filePath, cb) {
+    workspace.loadMiddleware(filePath, cb);
   }
-  static loadFacet(workspace, filePath, erroredFiles, next) {
-    workspace.loadFacet(filePath, function(err) {
-      if (err) erroredFiles.push(err);
-      next();
-    });
+  static loadFacet(workspace, filePath, cb) {
+    workspace.loadFacet(filePath, cb);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   "scripts": {
     "lint": "eslint .",
     "pretest": "node test/helpers/pretest.js",
-    "test": "npm run acceptance && npm run integration",
-    "acceptance": "grunt",
+    "test": "npm run unit && npm run acceptance && npm run integration",
+    "unit": "mocha test/unit/*.js",
     "integration": "mocha test/integration/*.js",
+    "acceptance": "grunt",
     "posttest": "npm run lint"
   },
   "repository": {

--- a/server/boot/nestRemoting.js
+++ b/server/boot/nestRemoting.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function initNestRouting(app) {
+  app.models.ModelDefinition.nestRemoting('properties');
+};

--- a/test/acceptance/use-cases/test-scripts/create-datasource.js
+++ b/test/acceptance/use-cases/test-scripts/create-datasource.js
@@ -9,6 +9,8 @@ const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
 
 const DataSourceDefinition = app.models.DataSourceDefinition;
+const TYPE_OF_TEST = 'acceptance';
+
 app.on('booted', function() {
   app.emit('ready');
 });
@@ -17,7 +19,8 @@ module.exports = function() {
   const testsuite = this;
   this.Given(/^that I have a workspace created from a template '(.+)'$/,
   function(templateName, next) {
-    testsuite.workspaceDir = testSupport.givenSandboxDir(templateName);
+    testsuite.workspaceDir =
+      testSupport.givenSandboxDir(TYPE_OF_TEST, templateName);
     testsuite.workspace =
       workspaceManager.getWorkspaceByFolder(testsuite.workspaceDir);
     testsuite.workspaceId = testsuite.workspace.getId();

--- a/test/acceptance/use-cases/test-scripts/create-facet.js
+++ b/test/acceptance/use-cases/test-scripts/create-facet.js
@@ -7,6 +7,7 @@ const path = require('path');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const Facet = app.models.Facet;
 app.on('booted', function() {
@@ -17,7 +18,7 @@ module.exports = function() {
   const testsuite = this;
   this.Given(/^that I have loaded the workspace '(.+)'$/,
   function(workspaceName, next) {
-    const dir = testSupport.givenSandboxDir(workspaceName);
+    const dir = testSupport.givenSandboxDir(TYPE_OF_TEST, workspaceName);
     testsuite.workspace = workspaceManager.getWorkspaceByFolder(dir);
     next();
   });

--- a/test/acceptance/use-cases/test-scripts/create-from-templates.js
+++ b/test/acceptance/use-cases/test-scripts/create-from-templates.js
@@ -8,6 +8,7 @@ const path = require('path');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const Workspace = app.models.Workspace;
 app.on('booted', function() {
@@ -24,7 +25,7 @@ module.exports = function() {
   function(templateName, next) {
     testsuite.templateName = templateName;
     testsuite.destinationPath =
-      testSupport.givenSandboxDir(testsuite.templateName);
+      testSupport.givenSandboxDir(TYPE_OF_TEST, testsuite.templateName);
     testSupport.givenEmptySandbox(testsuite.destinationPath, function(err) {
       if (err) return next(err);
       const data = {

--- a/test/acceptance/use-cases/test-scripts/create-middleware.js
+++ b/test/acceptance/use-cases/test-scripts/create-middleware.js
@@ -8,6 +8,7 @@ const path = require('path');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const Middleware = app.models.Middleware;
 app.on('booted', function() {
@@ -19,7 +20,7 @@ module.exports = function() {
   this.Given(/^The workspace '(.+)' has a '(.+)' phase$/,
   function(workspaceName, phaseName, next) {
     testsuite.middlewarePhase = phaseName;
-    const dir = testSupport.givenSandboxDir(workspaceName);
+    const dir = testSupport.givenSandboxDir(TYPE_OF_TEST, workspaceName);
     testsuite.workspace = workspaceManager.getWorkspaceByFolder(dir);
     next();
   });

--- a/test/acceptance/use-cases/test-scripts/create-model-config.js
+++ b/test/acceptance/use-cases/test-scripts/create-model-config.js
@@ -8,6 +8,7 @@ const path = require('path');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const ModelConfig = app.models.ModelConfig;
 app.on('booted', function() {
@@ -20,7 +21,7 @@ module.exports = function() {
   function(modelName, workspaceName, next) {
     testsuite.modelName = modelName;
     testsuite.modelId = 'common.models.' + modelName;
-    const dir = testSupport.givenSandboxDir(workspaceName);
+    const dir = testSupport.givenSandboxDir(TYPE_OF_TEST, workspaceName);
     testsuite.workspace = workspaceManager.getWorkspaceByFolder(dir);
     const model = testsuite.workspace.getModel(testsuite.modelId);
     expect(model).to.not.to.be.undefined();

--- a/test/acceptance/use-cases/test-scripts/create-models.js
+++ b/test/acceptance/use-cases/test-scripts/create-models.js
@@ -8,6 +8,7 @@ const path = require('path');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const ModelDefinition = app.models.ModelDefinition;
 const ModelMethod = app.models.ModelMethod;
@@ -22,7 +23,8 @@ module.exports = function() {
   const testsuite = this;
   this.Given(/^that I have loaded the workspace '(.+)'$/,
   function(templateName, next) {
-    testsuite.workspaceDir = testSupport.givenSandboxDir(templateName);
+    testsuite.workspaceDir =
+      testSupport.givenSandboxDir(TYPE_OF_TEST, templateName);
     testsuite.workspace =
       workspaceManager.getWorkspaceByFolder(testsuite.workspaceDir);
     testsuite.workspaceId = testsuite.workspace.getId();
@@ -65,7 +67,7 @@ module.exports = function() {
   this.Given(/^the model '(.+)' exists in workspace '(.+)'$/,
   function(modelName, workspaceName, next) {
     testsuite.modelId = 'common.models.' + modelName;
-    const dir = testSupport.givenSandboxDir(workspaceName);
+    const dir = testSupport.givenSandboxDir(TYPE_OF_TEST, workspaceName);
     testsuite.workspace = workspaceManager.getWorkspaceByFolder(dir);
     testsuite.workspaceId = testsuite.workspace.getId();
     const storedModel = testsuite.workspace.getModel(testsuite.modelId);

--- a/test/acceptance/use-cases/test-scripts/find-models.js
+++ b/test/acceptance/use-cases/test-scripts/find-models.js
@@ -8,6 +8,7 @@ const path = require('path');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const ModelDefinition = app.models.ModelDefinition;
 
@@ -16,7 +17,7 @@ module.exports = function() {
 
   this.When(/^I query for the model '(.+)' in workspace '(.+)'$/,
   function(modelName, workspaceName, next) {
-    const dir = testSupport.givenSandboxDir(workspaceName);
+    const dir = testSupport.givenSandboxDir(TYPE_OF_TEST, workspaceName);
     testsuite.workspace = workspaceManager.getWorkspaceByFolder(dir);
     testsuite.modelName = modelName;
     const modelId = 'common.models.' + testsuite.modelName;
@@ -24,9 +25,9 @@ module.exports = function() {
       where: {id: modelId},
     };
     const options = {workspaceId: testsuite.workspace.getId()};
-    ModelDefinition.find(filter, options, function(err, data) {
+    ModelDefinition.all(filter, options, function(err, data) {
       if (err) return next(err);
-      testsuite.modelDef = data;
+      testsuite.modelDef = data.length && data.length > 0 && data[0];
       next();
     });
   });

--- a/test/acceptance/use-cases/test-scripts/load-workspace.js
+++ b/test/acceptance/use-cases/test-scripts/load-workspace.js
@@ -9,6 +9,7 @@ const supertest = require('supertest');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const Workspace = app.models.Workspace;
 
@@ -20,7 +21,8 @@ module.exports = function() {
   const testsuite = this;
   this.Given(/^the '(.+)' workspace is not already loaded$/,
   function(templateName, next) {
-    testsuite.destinationPath = testSupport.givenSandboxDir(templateName);
+    testsuite.destinationPath =
+      testSupport.givenSandboxDir(TYPE_OF_TEST, templateName);
     const workspace =
       workspaceManager.getWorkspaceByFolder(testsuite.destinationPath);
     workspaceManager.deleteWorkspace(workspace.getId());
@@ -39,7 +41,8 @@ module.exports = function() {
       const data = response.body;
       expect(data.workspaceId).to.not.to.be.undefined();
       expect(data.errors.length).to.be.eql(0);
-      testsuite.destinationPath = testSupport.givenSandboxDir(templateName);
+      testsuite.destinationPath =
+        testSupport.givenSandboxDir(TYPE_OF_TEST, templateName);
       testsuite.workspace =
         workspaceManager.getWorkspaceByFolder(testsuite.destinationPath);
       expect(testsuite.workspace).to.not.to.be.undefined();

--- a/test/acceptance/use-cases/test-scripts/update-models.js
+++ b/test/acceptance/use-cases/test-scripts/update-models.js
@@ -8,6 +8,7 @@ const path = require('path');
 const testSupport = require('../../../helpers/test-support');
 const util = require('util');
 const workspaceManager = require('../../../../component/workspace-manager');
+const TYPE_OF_TEST = 'acceptance';
 
 const ModelDefinition = app.models.ModelDefinition;
 const ModelConfig = app.models.ModelConfig;

--- a/test/helpers/test-support.js
+++ b/test/helpers/test-support.js
@@ -5,11 +5,14 @@ const fs = require('fs-extra');
 const path = require('path');
 const sandboxDir = path.resolve(__dirname, '../sandbox/');
 const debug = require('debug')('test:util');
+const app = require('../..');
+const Workspace = app.models.Workspace;
 
 exports.givenEmptySandbox = givenEmptySandbox;
 exports.givenSandboxDir = givenSandboxDir;
 exports.initializePackage = initializePackage;
 exports.installSandboxPackages = installSandboxPackages;
+exports.givenBasicWorkspace = givenBasicWorkspace;
 
 function createSandboxDir(dir, cb) {
   fs.mkdirp(dir, function(err) {
@@ -18,6 +21,19 @@ function createSandboxDir(dir, cb) {
   });
 };
 
+function givenBasicWorkspace(typeOfTest, templateName, next) {
+  const destinationPath =
+    givenSandboxDir(typeOfTest, templateName);
+  givenEmptySandbox(destinationPath, function(err) {
+    if (err) return next(err);
+    const data = {
+      templateName: 'empty-server',
+      destinationPath: destinationPath,
+    };
+    Workspace.create(data, {}, next);
+  });
+}
+
 function givenEmptySandbox(sandboxDir, cb) {
   fs.remove(sandboxDir, function(err) {
     if (err) return cb(err);
@@ -25,8 +41,8 @@ function givenEmptySandbox(sandboxDir, cb) {
   });
 }
 
-function givenSandboxDir(templateName) {
-  return path.join(sandboxDir, templateName);
+function givenSandboxDir(typeOfTest, templateName) {
+  return path.join(sandboxDir, typeOfTest, templateName);
 }
 
 function initializePackage(dir, cb) {

--- a/test/integration/end-to-end.js
+++ b/test/integration/end-to-end.js
@@ -14,7 +14,7 @@ describe('end-to-end', function() {
   describe('api-server template', function() {
     this.timeout(50000);
     let app;
-    const dir = testSupport.givenSandboxDir('api-server');
+    const dir = testSupport.givenSandboxDir('acceptance', 'api-server');
     before(function loadApp(done) {
       testSupport.installSandboxPackages(dir, function(err) {
         if (err) return done(err);
@@ -56,7 +56,7 @@ describe('end-to-end', function() {
   describe('hello-world template', function() {
     this.timeout(50000);
     let app;
-    const dir = testSupport.givenSandboxDir('hello-world');
+    const dir = testSupport.givenSandboxDir('acceptance', 'hello-world');
     before(function loadApp(done) {
       testSupport.installSandboxPackages(dir, function(err) {
         if (err) return done(err);

--- a/test/unit/ModelDefinition.js
+++ b/test/unit/ModelDefinition.js
@@ -1,0 +1,75 @@
+// Copyright IBM Corp. 2014,2016. All Rights Reserved.
+// Node module: loopback-workspace
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+'use strict';
+
+const app = require('../../');
+const expect = require('../helpers/expect');
+const testSupport = require('../helpers/test-support');
+const ModelDefinition = app.models.ModelDefinition;
+
+describe('ModelDefinition', function() {
+  describe('CRUD', function() {
+    beforeEach(function(done) {
+      testSupport.givenBasicWorkspace('unit', 'empty-server', done);
+    });
+    describe('models', function() {
+      const test = this;
+      it('create models', function(done) {
+        test.model = {
+          id: 'common.models.TestModel',
+          facetName: 'common',
+          name: 'TestModel',
+          readonly: true,
+          strict: true,
+          public: true,
+          idInjection: true,
+        };
+        ModelDefinition.create(test.model, function(err, modelDef) {
+          if (err) return done(err);
+          ModelDefinition.find(function(err, models) {
+            if (err) return done(err);
+            models = models.filter(function(model) {
+              return model.id && (model.id === test.model.id);
+            });
+            test.modelDef = models && models.length && models[0];
+            expect(test.modelDef).not.to.be.undefined();
+            test.data = test.modelDef.toObject();
+            expect(Object.keys(test.data)).to.include.members([
+              'id',
+              'facetName',
+              'name',
+              'readonly',
+              'description',
+              'plural',
+              'base',
+              'strict',
+              'public',
+              'idInjection',
+            ]);
+            done();
+          });
+        });
+      });
+      it('create properties', function(done) {
+        const propertyDef = {
+          modelId: test.model.id,
+          name: 'property1',
+          type: 'string',
+          facetName: 'common',
+        };
+        test.modelDef.properties.create(propertyDef, {}, function(err, data) {
+          if (err) return done(err);
+          expect(Object.keys(data)).to.include.members([
+            'modelId',
+            'type',
+            'name',
+            'facetName',
+          ]);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add hasMany relation between workspace API - Model Definition and Model Properties

- [ ] - replace ModelDefinition.find with all()
- [ ] - enable use of juggler DAO.find() 
- [ ] - add relations in model def .json files
- [ ] - add unit tests to create models and properties
- [ ] - fix acceptance tests to replace ModelDefinition.find with all() 
- [ ] - create sandbox folders based on type of tests - unit, integration, acceptance
