### PR TITLE
Upgrade Explorer to fix security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lodash": "^4.5.1",
     "loopback": "^2.0.0",
     "loopback-boot": "^2.0.0",
-    "loopback-component-explorer": "^2.1.0",
+    "loopback-component-explorer": "^3.0.1",
     "loopback-datasource-juggler": "^2.27.0",
     "method-override": "^2.1.1",
     "morgan": "^1.2.0",


### PR DESCRIPTION
### Description

See
- https://snyk.io/vuln/npm:ejs:20161128
- https://snyk.io/vuln/npm:ejs:20161130
- https://snyk.io/vuln/npm:ejs:20161130-1

Note: we cannot upgrade to explorer 4.x because it does not support Node 0.10/0.12 which loopback-workspace still does support.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- Supersede #424

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
