### PR TITLE
Enable strictObjectIDCoercion for RoleMapping model

### DIFF
--- a/templates/projects/api-server/data.js
+++ b/templates/projects/api-server/data.js
@@ -43,6 +43,9 @@ template.server = {
     {
       name: 'RoleMapping',
       dataSource: 'db',
+      options: {
+        strictObjectIDCoercion: true,
+      },
       public: false,
     },
     {

--- a/templates/projects/hello-world/data.js
+++ b/templates/projects/hello-world/data.js
@@ -40,6 +40,9 @@ template.server = {
     {
       name: 'RoleMapping',
       dataSource: 'db',
+      options: {
+        strictObjectIDCoercion: true,
+      },
       public: false,
     },
     {

--- a/templates/projects/notes/data.js
+++ b/templates/projects/notes/data.js
@@ -40,6 +40,9 @@ template.server = {
     {
       name: 'RoleMapping',
       dataSource: 'db',
+      options: {
+        strictObjectIDCoercion: true,
+      },
       public: false,
     },
     {

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -394,6 +394,11 @@ describe('end-to-end', function() {
         .expect(422)
         .end(done);
     });
+
+    it('enables strictObjectIDCoercion for RoleMapping model', function() {
+      expect(app.models.RoleMapping.settings.strictObjectIDCoercion)
+        .to.equal(true);
+    });
   });
 
   describe('notes template', function() {
@@ -464,6 +469,11 @@ describe('end-to-end', function() {
         }
       });
     });
+
+    it('enables strictObjectIDCoercion for RoleMapping model', function() {
+      expect(app.models.RoleMapping.settings.strictObjectIDCoercion)
+        .to.equal(true);
+    });
   });
 
   describe('hello-world template', function() {
@@ -503,6 +513,11 @@ describe('end-to-end', function() {
       request(app)
         .get('/api/Messages')
         .expect(404, done);
+    });
+
+    it('enables strictObjectIDCoercion for RoleMapping model', function() {
+      expect(app.models.RoleMapping.settings.strictObjectIDCoercion)
+        .to.equal(true);
     });
   });
 


### PR DESCRIPTION
### Description

Force the RoleMapping model to always store ids as ObjectId when using MongoDB connector. This is needed to allow users to query RoleMapping via "principalId" property.

The solution uses a less-known feature where `server/model-config.json` can provide additional "options" to apply even to built-in models like `RoleMapping`.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- https://github.com/strongloop/loopback/issues/3121
- https://github.com/strongloop/loopback/issues/1441
- https://github.com/strongloop/loopback/pull/3198 

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
