### PR TITLE
templates: update strong-error-handler

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -26,7 +26,7 @@ template.package = {
     'helmet': '^1.3.0',
     'loopback-boot': '^2.6.5',
     'serve-favicon': '^2.0.1',
-    'strong-error-handler': '^1.0.1',
+    'strong-error-handler': '^2.0.0',
   },
   'devDependencies': {
     'eslint': '^3.17.1',


### PR DESCRIPTION
Upgrade strong-error-handler to version 2 (see https://github.com/strongloop/strong-error-handler/pull/42).

Requires #473 