### PR TITLE
Add engines.node: >=4 to scaffolded projects

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -12,6 +12,9 @@ template.supportedLBVersions = ['2.x', '3.x'];
 template.package = {
   'version': '1.0.0',
   'main': 'server/server.js',
+  'engines': {
+    'node': '>=4',
+  },
   'scripts': {
     'lint': 'eslint .',
     'start': 'node .',

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -134,7 +134,8 @@ describe('end-to-end', function() {
       }
     });
 
-    it('passes scaffolded tests', function(done) {
+    var isLegacyNode = /^0\./.test(process.version);
+    it.skipIf(isLegacyNode, 'passes scaffolded tests', function(done) {
       execNpm(['test'], { cwd: SANDBOX }, function(err, stdout, stderr) {
         done(err);
       });


### PR DESCRIPTION
### Description

Add `engines: { node: '>=4' }` to scaffolded projects

Also skip running `npm test` in the scaffolded project when
Node.js version if < 4 (typically when running on CI).

#### Related issues

This is a prerequisite for #467 and #472

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
