### PR TITLE
fix windows perms fail

### DIFF
--- a/common/models/config-file.js
+++ b/common/models/config-file.js
@@ -211,7 +211,8 @@ module.exports = function(ConfigFile) {
     });
 
     function find(pattern, cb) {
-      glob(pattern, { cwd: workspaceDir }, cb);
+      // set strict to false to avoid perm issues
+      glob(pattern, { cwd: workspaceDir, strict: false }, cb);
     }
   };
 


### PR DESCRIPTION
add strict flag for config-file

- ignore permission issues when looking for config files
- fixes windows and mac issues

