### PR TITLE
Disable context middleware to remove warning

### DIFF
--- a/server/config.json
+++ b/server/config.json
@@ -3,9 +3,7 @@
   "host": "0.0.0.0",
   "port": 3000,
   "remoting": {
-    "context": {
-      "enableHttpContext": false
-    },
+    "context": false,
     "rest": {
       "normalizeHttpPath": false,
       "xml": false


### PR DESCRIPTION
### Description

While testing `apic editor`, I noticed that a context-related warning is printed to stdout. Since we are not using the current context feature, there is no need to use this deprecated feature.

The change fixes the following warning reported on the first REST request:

```
loopback deprecated loopback#context middleware is deprecated.
node_modules/loopback/server/middleware/rest.js:60:32
```

See also http://loopback.io//doc/en/lb2/Using-current-context.html#fixing-deprecation-warnings