### PR TITLE
[WIP] Update template with a newer version of helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "loopback-workspace",
   "version": "4.0.0",
   "main": "server/server.js",
+  "engines": { 
+    "node": ">=4"
+  },
   "publishConfig": {
     "export-tests": true
   },
@@ -23,9 +26,9 @@
     "fs-extra": "^0.30.0",
     "glob": "^7.0.0",
     "lodash": "^4.5.1",
-    "loopback": "^2.0.0",
-    "loopback-boot": "^2.6.5",
-    "loopback-component-explorer": "^2.1.0",
+    "loopback": "^3.15.0",
+    "loopback-boot": "^3.1.0",
+    "loopback-component-explorer": "^5.2.0",
     "loopback-datasource-juggler": "^2.27.0",
     "method-override": "^2.1.1",
     "morgan": "^1.2.0",
@@ -34,8 +37,8 @@
     "semver": "^5.1.0",
     "serve-favicon": "^2.0.1",
     "stable": "^0.1.5",
-    "strong-error-handler": "^1.0.1",
-    "strong-globalize": "^2.6.6",
+    "strong-error-handler": "^2.3.0",
+    "strong-globalize": "^3.1.0",
     "strong-wait-till-listening": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "loopback": "^3.15.0",
     "loopback-boot": "^3.1.0",
     "loopback-component-explorer": "^5.2.0",
-    "loopback-datasource-juggler": "^2.27.0",
+    "loopback-datasource-juggler": "^3.13.0",
     "method-override": "^2.1.1",
     "morgan": "^1.2.0",
     "ncp": "^2.0.0",
@@ -50,7 +50,7 @@
     "grunt": "^1.0.0",
     "grunt-docular": "~0.1.2",
     "grunt-loopback-sdk-angular": "^1.2.0",
-    "mocha": "^2.4.5",
+    "mocha": "^3.0.0",
     "mysql": "^2.4.2",
     "read": "^1.0.5",
     "supertest": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "cookie-parser": "^1.3.2",
-    "debug": "^2.6.9",
+    "debug": "^3.1.0",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.0",
     "lodash": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "cookie-parser": "^1.3.2",
-    "debug": "^2.2.0",
+    "debug": "^2.6.9",
     "fs-extra": "^0.30.0",
     "glob": "^7.0.0",
     "lodash": "^4.5.1",

--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -23,7 +23,7 @@ template.package = {
   'dependencies': {
     'compression': '^1.0.3',
     'cors': '^2.5.2',
-    'helmet': '^1.3.0',
+    'helmet': '^3.8.2',
     'loopback-boot': '^2.6.5',
     'serve-favicon': '^2.0.1',
     'strong-error-handler': '^2.0.0',


### PR DESCRIPTION
Suggested by @bajtos , updating the template with a newer version of `helmet`. 
> We should update our project template to install the latest helmet version too, see https://github.com/strongloop/loopback-workspace/blob/8726d7ce7662051fe3236c1174d132c8ab038261/templates/projects/empty-server/data.js#L26

I've also updated the min version for `debug`