### PR TITLE
Update helmet version in empty server template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "loopback-workspace",
   "version": "4.0.0",
+  "engines": {
+    "node": ">=4"
+  },
   "main": "server/server.js",
   "publishConfig": {
     "export-tests": true

--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -23,7 +23,7 @@ template.package = {
   'dependencies': {
     'compression': '^1.0.3',
     'cors': '^2.5.2',
-    'helmet': '^1.3.0',
+    'helmet': '^3.10.0',
     'loopback-boot': '^2.6.5',
     'serve-favicon': '^2.0.1',
     'strong-error-handler': '^2.0.0',

--- a/templates/projects/empty-server/files/server/middleware.json
+++ b/templates/projects/empty-server/files/server/middleware.json
@@ -13,9 +13,7 @@
     },
     "helmet#xssFilter": {},
     "helmet#frameguard": {
-      "params": [
-        "deny"
-       ]
+      "params": { "action": "deny" }
     },
     "helmet#hsts": {
       "params": {


### PR DESCRIPTION
Fix CI:
- Updating the helmet version in the empty server template: https://github.com/strongloop/loopback-workspace/blob/master/templates/projects/empty-server/data.js
- Drop Node 0.10 and 0.12 from CI.
