### PR TITLE
change available-connectors.json to an object

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -1,5 +1,5 @@
-[
-  {
+{
+  "memory": {
     "name": "memory",
     "description": "In-memory db",
     "baseModel": "PersistedModel",
@@ -19,7 +19,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "kv-memory": {
     "name": "kv-memory",
     "description": "In-memory key-value connector",
     "baseModel": "KeyValueModel",
@@ -29,7 +29,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "ibm-object-storage": {
     "name": "ibm-object-storage",
     "description": "IBM Object Storage",
     "baseModel": "Model",
@@ -64,7 +64,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "db2": {
     "name": "db2",
     "description": "IBM DB2",
     "baseModel": "PersistedModel",
@@ -103,7 +103,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "dashdb": {
     "name": "dashdb",
     "description": "IBM DashDB",
     "baseModel": "PersistedModel",
@@ -139,7 +139,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "mqlight": {
     "name": "mqlight",
     "description": "IBM MQ Light",
     "baseModel": "Model",
@@ -166,7 +166,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "cloudant": {
     "name": "cloudant",
     "description": "IBM Cloudant DB",
     "baseModel": "PersistedModel",
@@ -199,7 +199,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "db2z": {
     "name": "db2z",
     "description": "IBM DB2 for z/OS",
     "baseModel": "PersistedModel",
@@ -235,7 +235,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "kv-extreme-scale": {
     "name": "kv-extreme-scale",
     "description": "IBM WebSphere eXtreme Scale key-value connector",
     "baseModel": "KeyValueModel",
@@ -259,7 +259,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "cassandra": {
     "name": "cassandra",
     "description": "Cassandra",
     "baseModel": "PersistedModel",
@@ -302,7 +302,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "kv-redis": {
     "name": "kv-redis",
     "description": "Redis key-value connector",
     "baseModel": "KeyValueModel",
@@ -335,7 +335,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "mongodb": {
     "name": "mongodb",
     "description": "MongoDB",
     "baseModel": "PersistedModel",
@@ -371,7 +371,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "mysql": {
     "name": "mysql",
     "description": "MySQL",
     "baseModel": "PersistedModel",
@@ -407,7 +407,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "postgresql": {
     "name": "postgresql",
     "description": "PostgreSQL",
     "baseModel": "PersistedModel",
@@ -443,7 +443,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "oracle": {
     "name": "oracle",
     "description": "Oracle",
     "baseModel": "PersistedModel",
@@ -479,7 +479,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "mssql": {
     "name": "mssql",
     "description": "Microsoft SQL",
     "baseModel": "PersistedModel",
@@ -515,7 +515,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "rest": {
     "name": "rest",
     "description": "REST services",
     "baseModel": "Model",
@@ -548,7 +548,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "soap": {
     "name": "soap",
     "description": "SOAP webservices",
     "baseModel": "Model",
@@ -580,7 +580,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "couchbase": {
     "name": "couchbase",
     "description": "Couchbase",
     "baseModel": "PersistedModel",
@@ -619,7 +619,7 @@
     },
     "supportedByStrongLoop": false
   },
-  {
+  "neo4j": {
     "name": "neo4j",
     "description": "Neo4j",
     "baseModel": "PersistedModel",
@@ -633,7 +633,7 @@
     },
     "supportedByStrongLoop": false
   },
-  {
+  "kafka": {
     "name": "kafka",
     "description": "Kafka",
     "baseModel": "PersistedModel",
@@ -647,7 +647,7 @@
     },
     "supportedByStrongLoop": false
   },
-  {
+  "saphana": {
     "name": "saphana",
     "description": "SAP HANA",
     "baseModel": "PersistedModel",
@@ -679,7 +679,7 @@
     },
     "supportedByStrongLoop": false
   },
-  {
+  "mail": {
     "name": "mail",
     "description": "Email",
     "baseModel": "Email",
@@ -695,7 +695,7 @@
     },
     "supportedByStrongLoop": true
   },
-  {
+  "elastic-search": {
     "name": "es",
     "description": "ElasticSearch",
     "baseModel": "PersistedModel",
@@ -735,7 +735,7 @@
     },
     "supportedByStrongLoop": false
   },
-  {
+  "zos-connect": {
     "name": "zosconnectee",
     "description": "z/OS Connect Enterprise Edition",
     "baseModel": "Model",
@@ -762,4 +762,4 @@
     },
     "supportedByStrongLoop": true
   }
-]
+}

--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -6,6 +6,7 @@
 var g = require('strong-globalize')();
 var _ = require('lodash');
 var helper = require('../../lib/helper');
+var connectorsObj = require('../../available-connectors');
 
 module.exports = function(Workspace) {
   var app = require('../../server/server');
@@ -425,7 +426,7 @@ module.exports = function(Workspace) {
      * @type {Array.<ConnectorMeta>}
      * @internal
      */
-    var staticConnectorList = require('../../available-connectors');
+    var staticConnectorList = _.values(connectorsObj);
 
     function isDependency(connector, pkg, cb) {
       var packageName;
@@ -446,6 +447,20 @@ module.exports = function(Workspace) {
       // default to not installed
       return cb(null, false);
     }
+
+    /**
+     * Map of connectors available on npm.
+     */
+    Workspace.mapOfAvailableConnectors = function() {
+      return connectorsObj;
+    };
+
+    /**
+     * Returns the connector metadata by key, or false if nothing is found.
+     */
+    Workspace.getConnectorByName = function(name) {
+      return connectorsObj[name] || false;
+    };
 
     /**
      * List of connectors available on npm.

--- a/test/workspace.js
+++ b/test/workspace.js
@@ -162,6 +162,19 @@ describe('Workspace', function() {
     });
   });
 
+  describe('project.getConnectorByName', function() {
+    it('should return false for unknown connector', function() {
+      var badConnector = Workspace.getConnectorByName('unknown-connector');
+      expect(badConnector).to.be.false();
+    });
+
+    it('should return a connector by name', function() {
+      var connector = Workspace.getConnectorByName('memory');
+      expect(connector.name).to.equal('memory');
+      expect(connector.description).to.equal('In-memory db');
+    });
+  });
+
   describe('project.listAvailableConnectors(cb)', function() {
     var connectors;
     before(function(done) {


### PR DESCRIPTION
### Description

Currently, our CLI tool has no way of skipping prompts for datasource selections. In order to do this, flags need to be used to bypass the prompts, but it is impractical to fetch a specific connector with current implementation of loading the controllers via an array. The PR changes the array implementation to that of a map, so that lookups for a specific connector could be faster.