### PR TITLE
Upgrade scaffolded API Explorer to v6.x

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -36,8 +36,8 @@ module.exports = function(Workspace) {
     var TEMPLATE_DIR = path.join(__dirname, '..', '..', 'templates', 'projects');
     var DEFAULT_TEMPLATE = 'api-server';
     var DEPENDENCIES_3_X = {
-      'loopback': '^3.0.0',
-      'loopback-component-explorer': '^5.0.0',
+      'loopback': '^3.19.0',
+      'loopback-component-explorer': '^6.0.0',
     };
     var DEPENDENCIES_2_X = {
       'loopback': '^2.22.0',


### PR DESCRIPTION
### Description

As a follow-up to https://github.com/strongloop/loopback-component-explorer/pull/232, bump the version specifier of API explorer used by LB 3.x projects to `^6.0.0`.

While we are making this change, upgrade the minimum LoopBack version to `3.19.0`, to support some of the recently added API Explorer features.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)