### PR TITLE
Update explorer to fix security vulnerabilities in dependencies

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -41,7 +41,7 @@ module.exports = function(Workspace) {
     };
     var DEPENDENCIES_2_X = {
       'loopback': '^2.22.0',
-      'loopback-component-explorer': '^2.4.0',
+      'loopback-component-explorer': '^5.4.0',
       'loopback-datasource-juggler': '^2.39.0',
     };
     var debug = require('debug')('workspace');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lodash": "^4.5.1",
     "loopback": "^2.0.0",
     "loopback-boot": "^2.6.5",
-    "loopback-component-explorer": "^2.1.0",
+    "loopback-component-explorer": "^6.0.1",
     "loopback-datasource-juggler": "^2.27.0",
     "method-override": "^2.1.1",
     "morgan": "^1.2.0",

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -583,8 +583,6 @@ describe('end-to-end', function() {
       expect(semver.gtr('3.0.0', dependencies.loopback)).to.be.true;
       expect(semver.gtr('3.0.0', dependencies['loopback-datasource-juggler']))
         .to.be.true;
-      expect(semver.gtr('3.0.0', dependencies['loopback-component-explorer']))
-        .to.be.true;
       done();
     });
 


### PR DESCRIPTION
See the discussion in https://github.com/strongloop/loopback-component-explorer/pull/246.

The CI is failing for unrelated reasons, the following pull request should fix that: https://github.com/strongloop/strong-remoting/pull/447.
