### PR TITLE
Update nsp version in template

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -19,7 +19,7 @@ template.package = {
   scripts: {
     lint: 'eslint .',
     start: 'node .',
-    posttest: 'npm run lint && nsp check',
+    posttest: 'npm run lint',
   },
   dependencies: {
     compression: '^1.0.3',
@@ -32,7 +32,6 @@ template.package = {
   devDependencies: {
     eslint: '^3.17.1',
     'eslint-config-loopback': '^8.0.0',
-    nsp: '^2.1.0',
   },
   // Avoid NPM warning
   repository: {


### PR DESCRIPTION
### Description
When creating a LoopBack application using CLI, it shows the generated application has vulnerabilities.
```
found 7 vulnerabilities (2 low, 4 moderate, 1 high)
  run `npm audit fix` to fix them, or `npm audit` for details
```
It is coming from the older version of `nsp`, which is one of the devDependencies. 

Please note that after this change, there is still one low vulnerabilities: lodash >=4.17.5  should be used. 
```
nsp > cli-table2 > lodash
```

Originated from: https://github.ibm.com/velox/toolkit/issues/1354