### PR TITLE
[DO NOT MERGE YET] Update LTS status of LoopBack 2.x/3.x versions

### DIFF
--- a/common/models/workspace.js
+++ b/common/models/workspace.js
@@ -62,8 +62,8 @@ module.exports = function(Workspace) {
 
     Workspace.getAvailableLBVersions = function(cb) {
       var availableLBVersions = {
-        '2.x': { description: g.f('long term support') },
-        '3.x': { description: g.f('current') },
+        '3.x': { description: g.f('Active Long Term Support') },
+        '2.x': { description: g.f('Maintenance Long Term Support') },
       };
       cb(null, availableLBVersions);
     };


### PR DESCRIPTION
### Description

When we release LoopBack 4 GA, LB 2 moves to Maintenance LTS and LB 3 moves to Active LTS.

#### Related issues

strongloop/loopback-next#1744

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)