### PR TITLE
update mongodb connector to 4.x

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -402,7 +402,7 @@
     },
     "package": {
       "name": "loopback-connector-mongodb",
-      "version": "^3.6.0"
+      "version": "^4.0.0"
     },
     "supportedByStrongLoop": true
   },


### PR DESCRIPTION
### Description

connect to https://github.com/strongloop/loopback-connector-mongodb/issues/476

The `generator-loopback` also fails on master, see https://github.com/strongloop/loopback-workspace/pull/534. I am going to track the fix using https://github.com/strongloop/loopback-workspace/pull/534 too.

#### Related issues
https://github.com/strongloop/loopback-connector-mongodb/issues/476