### PR TITLE
Adding useNewUrlParser option for mongodb available for v3.1 and above

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -398,6 +398,10 @@
       },
       "database": {
         "type": "string"
+      },
+      "useNewUrlParser":{
+        "type": "boolean",
+        "description": "Feature supported by MongoDB v3.1.0 and above"
       }
     },
     "package": {


### PR DESCRIPTION
### Description
Added useNewUrlParser which is 
option needed for v3.1 and above

#### Related issues

 


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
