### PR TITLE
Add npm audit to empty-server posttest

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -24,7 +24,7 @@ template.package = {
   scripts: {
     lint: 'eslint .',
     start: 'node .',
-    posttest: 'npm run lint',
+    posttest: 'npm run lint && npm audit',
   },
   dependencies: {
     compression: '^1.0.3',


### PR DESCRIPTION
### Description
`nsp` is longer supported, so instead of removing any security checks why not use the `npm audit`?

### Checklist

- [] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
