### PR TITLE
Remove `npm audit` from scaffolded `posttest` to fix CI builds

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -26,7 +26,7 @@ template.package = {
   scripts: {
     lint: 'eslint .',
     start: 'node .',
-    posttest: 'npm run lint && npm audit',
+    posttest: 'npm run lint',
   },
   dependencies: {
     compression: '^1.0.3',

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -1226,7 +1226,7 @@ function localInstall(cwd, cb) {
   const options = {
     cwd: cwd,
   };
-  const script = 'npm install';
+  const script = 'npm install --package-lock';
   debug('Running `%s` in %s', script, cwd);
   return exec(script, options, function(err, stdout, stderr) {
     debug('--npm stdout--\n%s\n--npm stderr--\n%s\n--end--',


### PR DESCRIPTION
New applications are created with a dependency on loopback-component-explorer, which depends on `swagger-ui@2` that's no longer maintained.

This version of swagger-ui has known security vulnerabilities which DO NOT apply to loopback-component-explorer, see the discussion in https://github.com/strongloop/loopback-component-explorer/issues/263.

Unfortunately, there is no way how to tell `npm` to ignore them.

This commit removes `npm audit` from the `posttest` script, to let `npm test` pass and thus fix our failing CI builds.

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
