### PR TITLE
Add loopback-connector-ibmi to available connectors

### DIFF
--- a/available-connectors.json
+++ b/available-connectors.json
@@ -409,12 +409,12 @@
     "settings": {
       "connectionString": {
         "type": "string",
-        "description": "Connection String (eg: DSN=MyDSN;DATABASE=MY_DB;HOSTNAME=MY_HOST;PORT=MY_PORT;PROTOCOL=TCPIP;UID=MY_UID;PWD=MY_PWD))"
+        "description": "Connection String (e.g.: DSN=MyDSN;SYSTEM=my.system;UID=MY_UID;PWD=MY_PWD))"
       }
     },
     "package": {
       "name": "loopback-connector-ibmi",
-      "version": "1.0.0"
+      "version": "^1.0.0"
     },
     "supportedByStrongLoop": true
   },

--- a/available-connectors.json
+++ b/available-connectors.json
@@ -399,6 +399,26 @@
     "supportedByStrongLoop": true
   },
   {
+    "name": "ibmi",
+    "description": "Db2 for i",
+    "baseModel": "PersistedModel",
+    "features": {
+      "discovery": true,
+      "migration": true
+    },
+    "settings": {
+      "connectionString": {
+        "type": "string",
+        "description": "Connection String (eg: DSN=MyDSN;DATABASE=MY_DB;HOSTNAME=MY_HOST;PORT=MY_PORT;PROTOCOL=TCPIP;UID=MY_UID;PWD=MY_PWD))"
+      }
+    },
+    "package": {
+      "name": "loopback-connector-ibmi",
+      "version": "1.0.0"
+    },
+    "supportedByStrongLoop": true
+  },
+  {
     "name": "mongodb",
     "description": "MongoDB",
     "baseModel": "PersistedModel",


### PR DESCRIPTION
Add support for `loopback-connector-ibmi`, which was just released and supported by StrongLoop.

Fixes #561 

## Checklist

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
