### PR TITLE
Use strong-error-handler v4 for new projects

### DIFF
--- a/templates/projects/empty-server/data.js
+++ b/templates/projects/empty-server/data.js
@@ -34,7 +34,7 @@ template.package = {
     helmet: '^3.10.0',
     'loopback-boot': '^2.6.5',
     'serve-favicon': '^2.0.1',
-    'strong-error-handler': '^3.0.0',
+    'strong-error-handler': '^4.0.0',
   },
   devDependencies: {
     eslint: '^3.17.1',


### PR DESCRIPTION
This is a follow-up for https://github.com/strongloop/strong-error-handler/pull/91. 

Please note this change affects only newly scaffolded LoopBack 3 projects. Existing projects will keep working as before and it's up to each user to decide if they want to upgrade `strong-error-handler` to v4 or stay on an older version.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-workspace) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
